### PR TITLE
Factor out data transformations

### DIFF
--- a/hacspec-scrambledb/scrambledb/src/data_transformations.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations.rs
@@ -1,13 +1,49 @@
+use hacspec_lib::Randomness;
+use libcrux::hpke::{kem::Nsk, HPKEConfig, HpkeSeal};
 use oprf::coprf::coprf_setup::{BlindingPrivateKey, BlindingPublicKey};
 
-use crate::{data_types::*, table::BlindIdentifier};
+use crate::{data_types::*, error::Error, SerializedHPKE};
+
+fn pseudonymization_context_string() -> Vec<u8> {
+    b"CoPRF-Context-Pseudonymization".to_vec()
+}
 
 pub fn blind_identifiable_datum(
     bpk: &BlindingPublicKey,
     ek: &[u8],
     datum: &IdentifiableDatum,
-) -> BlindedIdentifiableDatum {
-    todo!()
+    randomness: &mut Randomness,
+) -> Result<BlindedIdentifiableDatum, Error> {
+    // Blind orthonym towards data lake
+    let blinded_handle = BlindedIdentifiableHandle(oprf::coprf::coprf_online::blind(
+        *bpk,
+        datum.handle.as_bytes(),
+        pseudonymization_context_string(),
+        randomness,
+    )?);
+
+    // Encrypt data towards data lake
+    let HPKEConfig(_, kem, _, _) = crate::HPKE_CONF;
+    let encrypted_data_value = EncryptedDataValue {
+        attribute_name: datum.data_value.attribute_name.clone(),
+        value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
+            crate::HPKE_CONF,
+            ek,
+            b"Level-1",
+            b"",
+            &datum.data_value.value,
+            None,
+            None,
+            None,
+            randomness.bytes(Nsk(kem))?.to_vec(),
+        )?)
+        .to_bytes(),
+    };
+
+    Ok(BlindedIdentifiableDatum {
+        handle: blinded_handle,
+        data_value: encrypted_data_value,
+    })
 }
 
 pub fn pseudonymize_blinded_datum(

--- a/hacspec-scrambledb/scrambledb/src/data_transformations.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations.rs
@@ -1,5 +1,5 @@
 //! This module defines ScrambleDB transformations at the level of individual
-//! pieces of data as defined in [crate::data_types].
+//! pieces of data as defined in [`data_types`](crate::data_types).
 //!
 //! These transformations are:
 //! - blinding identifiable and pseudonymous data
@@ -26,14 +26,15 @@ const PSEUDONYMIZATION_CONTEXT: &[u8] = b"CoPRF-Context-Pseudonymization";
 /// generation.
 ///
 /// Inputs:
-/// - bpk: Receiver's blinding public key
-/// - ek: Receiver's public encryption key
-/// - datum: Identifiable datum
-/// - randomness: Random bytes
+/// - `bpk`: Receiver's blinding public key
+/// - `ek`: Receiver's public encryption key
+/// - `datum`: Identifiable data
+/// - `randomness`: Random bytes
 ///
 /// Output:
-/// [BlindedIdentifiableDatum] such that the datum's handle is blinded for
-/// CoPRF evaluation and the datum's value is level-1 encrypted.
+/// [Blinded data](crate::data_types::BlindedIdentifiableData) such that the
+/// datum's handle is blinded for CoPRF evaluation and the datum's value is
+/// level-1 encrypted.
 pub fn blind_identifiable_datum(
     bpk: &BlindingPublicKey,
     ek: &[u8],
@@ -61,16 +62,17 @@ pub fn blind_identifiable_datum(
 /// conversion.
 ///
 /// Inputs:
-/// - store_context: The data store's long term private state including the pseudonym
+/// - `store_context`: The data store's long term private state including the pseudonym
 ///   hardening keys
-/// - bpk: Receiver's blinding public key
-/// - ek: Receiver's public encryption key
-/// - datum: Pseudonymized datum
-/// - randomness: Random bytes
+/// - `bpk`: Receiver's blinding public key
+/// - `ek`: Receiver's public encryption key
+/// - `datum`: Pseudonymized data
+/// - `randomness`: Random bytes
 ///
 /// Output:
-/// [BlindedPseudonymizedDatum] such that the datum's handle is blinded for
-/// CoPRF conversion and the datum's value is level-1 encrypted.
+/// [Blinded pseudonymized data](BlindedPseudonymizedData) such that the
+/// datum's handle is blinded for CoPRF conversion and the datum's value is
+/// level-1 encrypted.
 pub fn blind_pseudonymized_datum(
     store_context: &StoreContext,
     bpk: &BlindingPublicKey,
@@ -97,16 +99,16 @@ pub fn blind_pseudonymized_datum(
 /// Obliviously pseudonymmize a blinded identifiable datum.
 ///
 /// Inputs:
-/// - coprf_context: The converter's CoPRF evaluation context
-/// - bpk: The receiver's blinding public key
-/// - ek: The receiver's public encryption key
-/// - datum: A blinded datum output by [blind_identifiable_datum]
-/// - randomness: Random bytes
+/// - `coprf_context`: The converter's CoPRF evaluation context
+/// - `bpk`: The receiver's blinding public key
+/// - `ek`: The receiver's public encryption key
+/// - `datum`: A blinded datum output by [`blind_identifiable_datum`]
+/// - `randomness`: Random bytes
 ///
 /// Output:
-/// [BlindedPseudonymizedDatum] such that the datum's blinded handle has been
-/// obliviously evaluated to a pseudonym and the datum's value has been level-2
-/// encrypted towards the receiver.
+/// [Blinded pseudonymized data](BlindedPseudonymizedData) such that the
+///  datum's blinded handle has been obliviously evaluated to a pseudonym and
+///  the datum's value has been level-2 encrypted towards the receiver.
 pub fn pseudonymize_blinded_datum(
     coprf_context: &CoPRFEvaluatorContext,
     bpk: &BlindingPublicKey,
@@ -139,16 +141,16 @@ pub fn pseudonymize_blinded_datum(
 /// Obliviously convert a blinded pseudonymous datum to a given target pseudonym key.
 ///
 /// Inputs:
-/// - coprf_context: The Converters CoPRF evaluation context
-/// - bpk: The receiver's blinding public key
-/// - ek: The receiver's public encryption key
-/// - conversion_target: Target pseudonym key identifier
-/// - randomness: Random bytes
+/// - `coprf_context`: The Converters CoPRF evaluation context
+/// - `bpk`: The receiver's blinding public key
+/// - `ek`: The receiver's public encryption key
+/// - `conversion_target`: Target pseudonym key identifier
+/// - `randomness`: Random bytes
 ///
 /// Output:
-/// [BlindedPseudonymizedDatum] such that the datum's pseudonymous handle is
-/// converted to the target pseudonym key and the datum's value is level-2
-/// encrypted towards the receiver.
+/// [Blinded pseudonymized data](BlindedPseudonymizedData)such that the
+/// datum's pseudonymous handle is converted to the target pseudonym key and
+/// the datum's value is level-2 encrypted towards the receiver.
 pub fn convert_blinded_datum(
     coprf_context: &CoPRFEvaluatorContext,
     bpk: &BlindingPublicKey,
@@ -187,15 +189,16 @@ pub fn convert_blinded_datum(
 /// Finalize a blinded pseudonymous datum for storage or analysis.
 ///
 /// Inputs:
-/// - store_context: The data store's long term private state including the
+/// - `store_context`: The data store's long term private state including the
 ///   receiver's coPRF unblinding key, private decryption key, as well as
 ///   pseudonym hardening key
-/// - datum: blinded pseudonymous datum output by [convert_blinded_datum] or
-///   [pseudonymize_blinded_datum]
+/// - `datum`: blinded pseudonymous datum output by [`convert_blinded_datum`] or
+///   [`pseudonymize_blinded_datum`]
 ///
 /// Output:
-/// [PseudonymizedDatum] such that the datum's pseudonymous handle has been
-/// unblinded and hardened and the datum's value has been decrypted.
+/// [Pseudonymized data](PseudonymizedData) such that the datum's pseudonymous
+/// handle has been unblinded and hardened and the datum's value has been
+/// decrypted.
 pub fn finalize_blinded_datum(
     store_context: &StoreContext,
     datum: &BlindedPseudonymizedData,

--- a/hacspec-scrambledb/scrambledb/src/data_transformations.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations.rs
@@ -16,17 +16,14 @@ use oprf::coprf::{
 
 use crate::{data_types::*, error::Error, setup::StoreContext, SerializedHPKE};
 
-fn pseudonymization_context_string() -> Vec<u8> {
-    b"CoPRF-Context-Pseudonymization".to_vec()
-}
+/// CoPRF context string for domain separation of intial pseudonymization.
+const PSEUDONYMIZATION_CONTEXT: &[u8] = b"CoPRF-Context-Pseudonymization";
 
-fn hpke_level_1_info() -> Vec<u8> {
-    b"Level-1".to_vec()
-}
+/// HPKE double encryption level 1 `info` string.
+const HPKE_LEVEL_1_INFO: &[u8] = b"Hpke-Level-1";
 
-fn hpke_level_2_info() -> Vec<u8> {
-    b"Level-2".to_vec()
-}
+/// HPKE double encryption level 2 `info` string.
+const HPKE_LEVEL_2_INFO: &[u8] = b"Hpke-Level-2";
 
 /// Blind an identifiable datum as a first step in initial pseudonym
 /// generation.
@@ -50,7 +47,7 @@ pub fn blind_identifiable_datum(
     let blinded_handle = BlindedIdentifiableHandle(blind(
         *bpk,
         datum.handle.as_bytes(),
-        pseudonymization_context_string(),
+        PSEUDONYMIZATION_CONTEXT.to_vec(),
         randomness,
     )?);
 
@@ -61,7 +58,7 @@ pub fn blind_identifiable_datum(
         value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
             crate::HPKE_CONF,
             ek,
-            &hpke_level_1_info(),
+            HPKE_LEVEL_1_INFO,
             b"",
             &datum.data_value.value,
             None,
@@ -113,7 +110,7 @@ pub fn blind_pseudonymized_datum(
         value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
             crate::HPKE_CONF,
             ek,
-            &hpke_level_1_info(),
+            HPKE_LEVEL_1_INFO,
             b"",
             &datum.data_value.value,
             None,
@@ -162,7 +159,7 @@ pub fn pseudonymize_blinded_datum(
         value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
             crate::HPKE_CONF,
             ek,
-            &hpke_level_2_info(),
+            HPKE_LEVEL_2_INFO,
             b"",
             &datum.data_value.value,
             None,
@@ -217,7 +214,7 @@ pub fn convert_blinded_datum(
         value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
             crate::HPKE_CONF,
             ek,
-            &hpke_level_2_info(),
+            HPKE_LEVEL_2_INFO,
             b"",
             &datum.data_value.value,
             None,
@@ -255,7 +252,7 @@ pub fn finalize_blinded_datum(
         crate::HPKE_CONF,
         &outer_encryption,
         &store_context.hpke_sk,
-        b"Level-2",
+        HPKE_LEVEL_2_INFO,
         b"",
         None,
         None,
@@ -269,7 +266,7 @@ pub fn finalize_blinded_datum(
             crate::HPKE_CONF,
             &inner_encryption,
             &store_context.hpke_sk,
-            b"Level-1",
+            HPKE_LEVEL_1_INFO,
             b"",
             None,
             None,

--- a/hacspec-scrambledb/scrambledb/src/data_transformations.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations.rs
@@ -8,6 +8,13 @@ fn pseudonymization_context_string() -> Vec<u8> {
     b"CoPRF-Context-Pseudonymization".to_vec()
 }
 
+fn hpke_level_1_info() -> Vec<u8> {
+    b"Level-1".to_vec()
+}
+
+fn hpke_level_2_info() -> Vec<u8> {
+    b"Level-2".to_vec()
+}
 pub fn blind_identifiable_datum(
     bpk: &BlindingPublicKey,
     ek: &[u8],
@@ -22,14 +29,14 @@ pub fn blind_identifiable_datum(
         randomness,
     )?);
 
-    // Encrypt data towards data lake
+    // Encrypt data towards receiver
     let HPKEConfig(_, kem, _, _) = crate::HPKE_CONF;
     let encrypted_data_value = EncryptedDataValue {
         attribute_name: datum.data_value.attribute_name.clone(),
         value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
             crate::HPKE_CONF,
             ek,
-            b"Level-1",
+            &hpke_level_1_info(),
             b"",
             &datum.data_value.value,
             None,
@@ -111,7 +118,7 @@ pub fn pseudonymize_blinded_datum(
         value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
             crate::HPKE_CONF,
             ek,
-            b"Level-2",
+            &hpke_level_2_info(),
             b"",
             &datum.data_value.value,
             None,
@@ -156,7 +163,7 @@ pub fn convert_blinded_datum(
         value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
             crate::HPKE_CONF,
             ek,
-            b"Level-2",
+            &hpke_level_2_info(),
             b"",
             &datum.data_value.value,
             None,

--- a/hacspec-scrambledb/scrambledb/src/data_transformations.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations.rs
@@ -92,7 +92,7 @@ pub fn blind_pseudonymized_datum(
     })
 }
 pub fn pseudonymize_blinded_datum(
-    coprf_context: oprf::coprf::coprf_setup::CoPRFEvaluatorContext,
+    coprf_context: &oprf::coprf::coprf_setup::CoPRFEvaluatorContext,
     bpk: &BlindingPublicKey,
     ek: &[u8],
     datum: &BlindedIdentifiableDatum,
@@ -133,7 +133,7 @@ pub fn pseudonymize_blinded_datum(
 }
 
 pub fn convert_blinded_datum(
-    coprf_context: oprf::coprf::coprf_setup::CoPRFEvaluatorContext,
+    coprf_context: &oprf::coprf::coprf_setup::CoPRFEvaluatorContext,
     bpk: &BlindingPublicKey,
     ek: &[u8],
     conversion_target: &[u8],

--- a/hacspec-scrambledb/scrambledb/src/data_transformations.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations.rs
@@ -1,0 +1,36 @@
+use oprf::coprf::coprf_setup::{BlindingPrivateKey, BlindingPublicKey};
+
+use crate::{data_types::*, table::BlindIdentifier};
+
+pub fn blind_identifiable_datum(
+    bpk: &BlindingPublicKey,
+    ek: &[u8],
+    datum: &IdentifiableDatum,
+) -> BlindedIdentifiableDatum {
+    todo!()
+}
+
+pub fn pseudonymize_blinded_datum(
+    bpk: &BlindingPublicKey,
+    ek: &[u8],
+    datum: &BlindedIdentifiableDatum,
+) -> BlindedPseudonymizedDatum {
+    todo!()
+}
+
+pub fn convert_blinded_datum(
+    bpk: &BlindingPublicKey,
+    ek: &[u8],
+    conversion_target: &[u8],
+    datum: &BlindedPseudonymizedDatum,
+) -> BlindedPseudonymizedDatum {
+    todo!()
+}
+
+pub fn finalize_blinded_datum(
+    bpk: &BlindingPrivateKey,
+    dk: &[u8],
+    datum: &BlindedPseudonymizedDatum,
+) -> PseudonymizedDatum {
+    todo!()
+}

--- a/hacspec-scrambledb/scrambledb/src/data_transformations.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations.rs
@@ -1,3 +1,12 @@
+//! This module defines ScrambleDB transformations at the level of individual
+//! pieces of data as defined in [crate::data_types].
+//!
+//! These transformations are:
+//! - blinding identifiable and pseudonymous data
+//! - pseudonymizing blinded identifiable data
+//! - converting blinded pseudonymous data
+//! - finalizing blinded pseudonymous data
+
 use hacspec_lib::Randomness;
 use libcrux::hpke::{kem::Nsk, HPKEConfig, HpkeOpen, HpkeSeal};
 use oprf::coprf::{

--- a/hacspec-scrambledb/scrambledb/src/data_transformations.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations.rs
@@ -232,14 +232,14 @@ pub fn convert_blinded_datum(
 }
 
 /// Finalize a blinded pseudonymous datum for storage or analysis.
-/// 
+///
 /// Inputs:
 /// - store_context: The data store's long term private state including the
 ///   receiver's coPRF unblinding key, private decryption key, as well as
-///   pseudonym hardening key 
+///   pseudonym hardening key
 /// - datum: blinded pseudonymous datum output by [convert_blinded_datum] or
 ///   [pseudonymize_blinded_datum]
-/// 
+///
 /// Output:
 /// [PseudonymizedDatum] such that the datum's pseudonymous handle has been
 /// unblinded and hardened and the datum's value has been decrypted.

--- a/hacspec-scrambledb/scrambledb/src/data_transformations.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations.rs
@@ -31,9 +31,9 @@ fn hpke_level_2_info() -> Vec<u8> {
 pub fn blind_identifiable_datum(
     bpk: &BlindingPublicKey,
     ek: &[u8],
-    datum: &IdentifiableDatum,
+    datum: &IdentifiableData,
     randomness: &mut Randomness,
-) -> Result<BlindedIdentifiableDatum, Error> {
+) -> Result<BlindedIdentifiableData, Error> {
     // Blind orthonym towards receiver
     let blinded_handle = BlindedIdentifiableHandle(oprf::coprf::coprf_online::blind(
         *bpk,
@@ -60,7 +60,7 @@ pub fn blind_identifiable_datum(
         .to_bytes(),
     };
 
-    Ok(BlindedIdentifiableDatum {
+    Ok(BlindedIdentifiableData {
         handle: blinded_handle,
         data_value: encrypted_data_value,
     })
@@ -84,9 +84,9 @@ pub fn blind_pseudonymized_datum(
     store_context: &StoreContext,
     bpk: &BlindingPublicKey,
     ek: &[u8],
-    datum: &PseudonymizedDatum,
+    datum: &PseudonymizedData,
     randomness: &mut Randomness,
-) -> Result<BlindedPseudonymizedDatum, Error> {
+) -> Result<BlindedPseudonymizedData, Error> {
     // Blind recovered raw pseudonym towards receiver
     let blinded_handle =
         BlindedPseudonymizedHandle(oprf::coprf::coprf_online::prepare_blind_convert(
@@ -113,7 +113,7 @@ pub fn blind_pseudonymized_datum(
         .to_bytes(),
     };
 
-    Ok(BlindedPseudonymizedDatum {
+    Ok(BlindedPseudonymizedData {
         handle: blinded_handle,
         data_value: encrypted_data_value,
     })
@@ -136,9 +136,9 @@ pub fn pseudonymize_blinded_datum(
     coprf_context: &oprf::coprf::coprf_setup::CoPRFEvaluatorContext,
     bpk: &BlindingPublicKey,
     ek: &[u8],
-    datum: &BlindedIdentifiableDatum,
+    datum: &BlindedIdentifiableData,
     randomness: &mut Randomness,
-) -> Result<BlindedPseudonymizedDatum, Error> {
+) -> Result<BlindedPseudonymizedData, Error> {
     let key = oprf::coprf::coprf_setup::derive_key(
         &coprf_context,
         datum.data_value.attribute_name.as_bytes(),
@@ -170,7 +170,7 @@ pub fn pseudonymize_blinded_datum(
         .to_bytes(),
     };
 
-    Ok(BlindedPseudonymizedDatum { handle, data_value })
+    Ok(BlindedPseudonymizedData { handle, data_value })
 }
 
 /// Obliviously convert a blinded pseudonymous datum to a given target pseudonym key.
@@ -191,9 +191,9 @@ pub fn convert_blinded_datum(
     bpk: &BlindingPublicKey,
     ek: &[u8],
     conversion_target: &[u8],
-    datum: &BlindedPseudonymizedDatum,
+    datum: &BlindedPseudonymizedData,
     randomness: &mut Randomness,
-) -> Result<BlindedPseudonymizedDatum, Error> {
+) -> Result<BlindedPseudonymizedData, Error> {
     let key_from = oprf::coprf::coprf_setup::derive_key(
         &coprf_context,
         datum.data_value.attribute_name.as_bytes(),
@@ -228,7 +228,7 @@ pub fn convert_blinded_datum(
         .to_bytes(),
     };
 
-    Ok(BlindedPseudonymizedDatum { handle, data_value })
+    Ok(BlindedPseudonymizedData { handle, data_value })
 }
 
 /// Finalize a blinded pseudonymous datum for storage or analysis.
@@ -245,8 +245,8 @@ pub fn convert_blinded_datum(
 /// unblinded and hardened and the datum's value has been decrypted.
 pub fn finalize_blinded_datum(
     store_context: &StoreContext,
-    datum: &BlindedPseudonymizedDatum,
-) -> Result<PseudonymizedDatum, Error> {
+    datum: &BlindedPseudonymizedData,
+) -> Result<PseudonymizedData, Error> {
     let handle = FinalizedPseudonym(store_context.finalize_pseudonym(datum.handle.0)?);
 
     let outer_encryption = SerializedHPKE::from_bytes(&datum.data_value.value).to_hpke_ct();
@@ -277,5 +277,5 @@ pub fn finalize_blinded_datum(
         )?,
     };
 
-    Ok(PseudonymizedDatum { handle, data_value })
+    Ok(PseudonymizedData { handle, data_value })
 }

--- a/hacspec-scrambledb/scrambledb/src/data_transformations/double_hpke.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations/double_hpke.rs
@@ -1,5 +1,6 @@
 //! This module defines HPKE-based double encryption and decryption for use in
-//! individual data tranformations as defined in [crate::data_transformations].
+//! individual data tranformations as defined in
+//! [`data_transformations`](crate::data_transformations).
 //!
 //! A plain text data value can be encrypted once to obtain a level-1
 //! encryption of the data value.
@@ -33,15 +34,15 @@ const HPKE_LEVEL_2_INFO: &[u8] = b"Hpke-Level-2";
 /// Level-1 encrypt a plain text data value.
 ///
 /// Inputs:
-/// - data_value: A plain text data value
-/// - ek: The receivers public encryption key
-/// - randomness: Random bytes
+/// - `data_value`: A plain text data value
+/// - `ek`: The receivers public encryption key
+/// - `randomness`: Random bytes
 ///
 /// Output:
 /// A level-1 encrypted data value.
 ///
 /// Raises:
-/// - CorruptedData: If the internal encryption fails.
+/// - `CorruptedData`: If the internal encryption fails.
 ///
 /// Panics:
 /// - on insufficient randomness
@@ -73,16 +74,16 @@ pub(crate) fn hpke_seal_level_1(
 /// Level-2 encrypt a level-1 encrypted data value.
 ///
 /// Inputs:
-/// - data_value: A level-1 encrypted data value
-/// - ek: The receivers public encryption key
-/// - randomness: Random bytes
+/// - `data_value`: A level-1 encrypted data value
+/// - `ek`: The receivers public encryption key
+/// - `randomness`: Random bytes
 ///
 /// Output:
 /// A level-2 encrypted data value.
 ///
 /// Raises:
-/// - InvalidInput: If the input data value is not level-1 encrypted.
-/// - CorruptedData: If the internal encryption fails.
+/// - `InvalidInput`: If the input data value is not level-1 encrypted.
+/// - `CorruptedData`: If the internal encryption fails.
 ///
 /// Panics:
 /// - on insufficient randomness
@@ -118,15 +119,15 @@ pub(crate) fn hpke_seal_level_2(
 /// Decrypt a level-2 encrypted data value.
 ///
 /// Inputs:
-/// - data_value: A Level-2 encrypted data value
-/// - sk: The receiver's decryption key
+/// - `data_value`: A Level-2 encrypted data value
+/// - `sk`: The receiver's decryption key
 ///
 /// Outputs:
 /// A plain text data value.
 ///
 /// Raises:
-/// - InvalidInput: If the input data value is not level-2 encrypted.
-/// - CorruptedData: If the internal decryption fails, e.g. because of
+/// - `InvalidInput`: If the input data value is not level-2 encrypted.
+/// - `CorruptedData`: If the internal decryption fails, e.g. because of
 ///   inconsistent level-1 and level-2 receivers.
 pub(crate) fn hpke_open_level_2(
     data_value: &EncryptedDataValue,

--- a/hacspec-scrambledb/scrambledb/src/data_transformations/double_hpke.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_transformations/double_hpke.rs
@@ -1,0 +1,165 @@
+//! This module defines HPKE-based double encryption and decryption for use in
+//! individual data tranformations as defined in [crate::data_transformations].
+//!
+//! A plain text data value can be encrypted once to obtain a level-1
+//! encryption of the data value.
+//!
+//! A level-1 encrypted data value can be encrypted a second time to obtain a
+//! level-2 encryption of the data value.
+//!
+//! Only level-2 encrypted data values can be decrypted, and only if both
+//! encryptions were performed towards the same receiver.
+
+use libcrux::hpke::kem::Nsk;
+
+use libcrux::hpke::{HpkeOpen, HpkeSeal};
+
+use crate::SerializedHPKE;
+
+use crate::data_types::{DataValue, EncryptedDataValue};
+
+use libcrux::hpke::HPKEConfig;
+
+use crate::error::Error;
+
+use hacspec_lib::Randomness;
+
+/// HPKE double encryption level 1 `info` string.
+const HPKE_LEVEL_1_INFO: &[u8] = b"Hpke-Level-1";
+
+/// HPKE double encryption level 2 `info` string.
+const HPKE_LEVEL_2_INFO: &[u8] = b"Hpke-Level-2";
+
+/// Level-1 encrypt a plain text data value.
+///
+/// Inputs:
+/// - data_value: A plain text data value
+/// - ek: The receivers public encryption key
+/// - randomness: Random bytes
+///
+/// Output:
+/// A level-1 encrypted data value.
+///
+/// Raises:
+/// - CorruptedData: If the internal encryption fails.
+///
+/// Panics:
+/// - on insufficient randomness
+pub(crate) fn hpke_seal_level_1(
+    data_value: &DataValue,
+    ek: &[u8],
+    randomness: &mut Randomness,
+) -> Result<EncryptedDataValue, Error> {
+    let HPKEConfig(_, kem, _, _) = crate::HPKE_CONF;
+    let encrypted_data_value = EncryptedDataValue {
+        attribute_name: data_value.attribute_name.clone(),
+        value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
+            crate::HPKE_CONF,
+            ek,
+            HPKE_LEVEL_1_INFO,
+            b"",
+            &data_value.value,
+            None,
+            None,
+            None,
+            randomness.bytes(Nsk(kem)).unwrap().to_vec(),
+        )?)
+        .to_bytes(),
+        encryption_level: 1u8,
+    };
+    Ok(encrypted_data_value)
+}
+
+/// Level-2 encrypt a level-1 encrypted data value.
+///
+/// Inputs:
+/// - data_value: A level-1 encrypted data value
+/// - ek: The receivers public encryption key
+/// - randomness: Random bytes
+///
+/// Output:
+/// A level-2 encrypted data value.
+///
+/// Raises:
+/// - InvalidInput: If the input data value is not level-1 encrypted.
+/// - CorruptedData: If the internal encryption fails.
+///
+/// Panics:
+/// - on insufficient randomness
+pub(crate) fn hpke_seal_level_2(
+    data_value: &EncryptedDataValue,
+    ek: &[u8],
+    randomness: &mut Randomness,
+) -> Result<EncryptedDataValue, Error> {
+    if data_value.encryption_level != 1u8 {
+        return Err(Error::InvalidInput);
+    }
+
+    let HPKEConfig(_, kem, _, _) = crate::HPKE_CONF;
+    let data_value = EncryptedDataValue {
+        attribute_name: data_value.attribute_name.clone(),
+        value: SerializedHPKE::from_hpke_ct(&HpkeSeal(
+            crate::HPKE_CONF,
+            ek,
+            HPKE_LEVEL_2_INFO,
+            b"",
+            &data_value.value,
+            None,
+            None,
+            None,
+            randomness.bytes(Nsk(kem)).unwrap().to_vec(),
+        )?)
+        .to_bytes(),
+        encryption_level: 2u8,
+    };
+    Ok(data_value)
+}
+
+/// Decrypt a level-2 encrypted data value.
+///
+/// Inputs:
+/// - data_value: A Level-2 encrypted data value
+/// - sk: The receiver's decryption key
+///
+/// Outputs:
+/// A plain text data value.
+///
+/// Raises:
+/// - InvalidInput: If the input data value is not level-2 encrypted.
+/// - CorruptedData: If the internal decryption fails, e.g. because of
+///   inconsistent level-1 and level-2 receivers.
+pub(crate) fn hpke_open_level_2(
+    data_value: &EncryptedDataValue,
+    sk: &[u8],
+) -> Result<DataValue, Error> {
+    if data_value.encryption_level != 2u8 {
+        return Err(Error::InvalidInput);
+    }
+
+    let outer_encryption = SerializedHPKE::from_bytes(&data_value.value).to_hpke_ct();
+    let inner_encryption = SerializedHPKE::from_bytes(&HpkeOpen(
+        crate::HPKE_CONF,
+        &outer_encryption,
+        sk,
+        HPKE_LEVEL_2_INFO,
+        b"",
+        None,
+        None,
+        None,
+    )?)
+    .to_hpke_ct();
+    let data_value = DataValue {
+        attribute_name: data_value.attribute_name.clone(),
+        value: HpkeOpen(
+            crate::HPKE_CONF,
+            &inner_encryption,
+            sk,
+            HPKE_LEVEL_1_INFO,
+            b"",
+            None,
+            None,
+            None,
+        )?,
+    };
+    Ok(data_value)
+}

--- a/hacspec-scrambledb/scrambledb/src/data_types.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_types.rs
@@ -1,33 +1,61 @@
+//! This module defines data structures for indvidual pieces of data in
+//! ScrambleDB.
+//!
+//! A value generally consists of a handle and a data value. Handles can be
+//! identifiable or pseudonymous and either form can also be blinded. Data
+//! values may be in plain text or encrypted and always carry with them the
+//! name of the attribute they belong to in plain text.
+/// A type for finalized pseudonyms, i.e. those which have been hardened for
+/// storage by applying a PRP.
 pub struct FinalizedPseudonym(pub(crate) [u8; 64]);
-pub struct BlindedIdentifiableHandle(pub(crate) oprf::coprf::coprf_online::BlindInput);
-pub struct BlindedPseudonymizedHandle(pub(crate) oprf::coprf::coprf_online::BlindOutput);
+/// A type for blinded identifiable handles.
+pub struct BlindedIdentifiableHandle(pub(crate) BlindInput);
+/// A type for  blinded pseudonymous handles.
+pub struct BlindedPseudonymizedHandle(pub(crate) BlindOutput);
 
+/// A plain text data value.
 pub struct DataValue {
-    pub(crate) attribute_name: String,
+    /// A byte string encoding the data value.
     pub(crate) value: Vec<u8>,
+    /// The name of the attribute the value belongs to.
+    pub(crate) attribute_name: String,
 }
-
+/// An encrypted data value.
 pub struct EncryptedDataValue {
-    pub(crate) attribute_name: String,
+    /// A byte string encoding the encrypted data value.
     pub(crate) value: Vec<u8>,
+    /// The name of the attribute the value belongs to.
+    pub(crate) attribute_name: String,
 }
 
 pub struct IdentifiableDatum {
+/// An identifiable piece of data.
+    /// A plain text handle.
     pub(crate) handle: String,
+    /// A plain text data value.
     pub(crate) data_value: DataValue,
 }
 
 pub struct BlindedIdentifiableDatum {
+/// The blinded version of an identifiable piece of data.
+    /// A blinded plain text handle.
     pub(crate) handle: BlindedIdentifiableHandle,
+    /// An encrypted data value.
     pub(crate) data_value: EncryptedDataValue,
 }
 
 pub struct BlindedPseudonymizedDatum {
+/// The blinded version of a pseudonymized piece of data.
+    /// A blinded pseudonymous handle.
     pub(crate) handle: BlindedPseudonymizedHandle,
+    /// An encrypted data value.
     pub(crate) data_value: EncryptedDataValue,
 }
 
 pub struct PseudonymizedDatum {
+/// A pseudonymized piece of data.
+    /// A pseudonymous handle.
     pub(crate) handle: FinalizedPseudonym,
+    /// A plain text data value.
     pub(crate) data_value: DataValue,
 }

--- a/hacspec-scrambledb/scrambledb/src/data_types.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_types.rs
@@ -29,6 +29,8 @@ pub struct EncryptedDataValue {
     pub(crate) value: Vec<u8>,
     /// The name of the attribute the value belongs to.
     pub(crate) attribute_name: String,
+    /// The encryption level, as understood in terms of [crate::data_transformations::double_hpke].
+    pub(crate) encryption_level: u8,
 }
 
 /// An identifiable piece of data.

--- a/hacspec-scrambledb/scrambledb/src/data_types.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_types.rs
@@ -1,0 +1,33 @@
+pub struct Pseudonym(oprf::coprf::coprf_online::Output);
+pub struct BlindedIdentifiableHandle(oprf::coprf::coprf_online::BlindInput);
+pub struct BlindedPseudonymizedHandle(oprf::coprf::coprf_online::BlindOutput);
+
+pub struct DataValue {
+    attribute_name: String,
+    value: Vec<u8>,
+}
+
+pub struct EncryptedDataValue {
+    attribute_name: String,
+    value: Vec<u8>,
+}
+
+pub struct IdentifiableDatum {
+    handle: String,
+    data_value: DataValue,
+}
+
+pub struct BlindedIdentifiableDatum {
+    handle: BlindedIdentifiableHandle,
+    data_value: EncryptedDataValue,
+}
+
+pub struct BlindedPseudonymizedDatum {
+    handle: BlindedPseudonymizedHandle,
+    data_value: EncryptedDataValue,
+}
+
+pub struct PseudonymizedDatum {
+    handle: Pseudonym,
+    data_value: DataValue,
+}

--- a/hacspec-scrambledb/scrambledb/src/data_types.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_types.rs
@@ -5,6 +5,9 @@
 //! identifiable or pseudonymous and either form can also be blinded. Data
 //! values may be in plain text or encrypted and always carry with them the
 //! name of the attribute they belong to in plain text.
+
+use oprf::coprf::coprf_online::{BlindInput, BlindOutput};
+
 /// A type for finalized pseudonyms, i.e. those which have been hardened for
 /// storage by applying a PRP.
 pub struct FinalizedPseudonym(pub(crate) [u8; 64]);

--- a/hacspec-scrambledb/scrambledb/src/data_types.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_types.rs
@@ -1,6 +1,7 @@
-pub struct Pseudonym(oprf::coprf::coprf_online::Output);
+pub struct RawPseudonym(oprf::coprf::coprf_online::Output);
+pub struct FinalizedPseudonym(pub(crate) [u8; 64]);
 pub struct BlindedIdentifiableHandle(pub(crate) oprf::coprf::coprf_online::BlindInput);
-pub struct BlindedPseudonymizedHandle(oprf::coprf::coprf_online::BlindOutput);
+pub struct BlindedPseudonymizedHandle(pub(crate) oprf::coprf::coprf_online::BlindOutput);
 
 pub struct DataValue {
     pub(crate) attribute_name: String,
@@ -28,6 +29,6 @@ pub struct BlindedPseudonymizedDatum {
 }
 
 pub struct PseudonymizedDatum {
-    pub(crate) handle: Pseudonym,
+    pub(crate) handle: FinalizedPseudonym,
     pub(crate) data_value: DataValue,
 }

--- a/hacspec-scrambledb/scrambledb/src/data_types.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_types.rs
@@ -1,4 +1,3 @@
-pub struct RawPseudonym(oprf::coprf::coprf_online::Output);
 pub struct FinalizedPseudonym(pub(crate) [u8; 64]);
 pub struct BlindedIdentifiableHandle(pub(crate) oprf::coprf::coprf_online::BlindInput);
 pub struct BlindedPseudonymizedHandle(pub(crate) oprf::coprf::coprf_online::BlindOutput);

--- a/hacspec-scrambledb/scrambledb/src/data_types.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_types.rs
@@ -44,17 +44,17 @@ pub struct IdentifiableData {
 /// The blinded version of an identifiable piece of data.
 pub struct BlindedIdentifiableData {
     /// A blinded plain text handle.
-    pub(crate) handle: BlindedIdentifiableHandle,
+    pub(crate) blinded_handle: BlindedIdentifiableHandle,
     /// An encrypted data value.
-    pub(crate) data_value: EncryptedDataValue,
+    pub(crate) encrypted_data_value: EncryptedDataValue,
 }
 
 /// The blinded version of a pseudonymized piece of data.
 pub struct BlindedPseudonymizedData {
     /// A blinded pseudonymous handle.
-    pub(crate) handle: BlindedPseudonymizedHandle,
+    pub(crate) blinded_handle: BlindedPseudonymizedHandle,
     /// An encrypted data value.
-    pub(crate) data_value: EncryptedDataValue,
+    pub(crate) encrypted_data_value: EncryptedDataValue,
 }
 
 /// A pseudonymized piece of data.

--- a/hacspec-scrambledb/scrambledb/src/data_types.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_types.rs
@@ -1,33 +1,33 @@
 pub struct Pseudonym(oprf::coprf::coprf_online::Output);
-pub struct BlindedIdentifiableHandle(oprf::coprf::coprf_online::BlindInput);
+pub struct BlindedIdentifiableHandle(pub(crate) oprf::coprf::coprf_online::BlindInput);
 pub struct BlindedPseudonymizedHandle(oprf::coprf::coprf_online::BlindOutput);
 
 pub struct DataValue {
-    attribute_name: String,
-    value: Vec<u8>,
+    pub(crate) attribute_name: String,
+    pub(crate) value: Vec<u8>,
 }
 
 pub struct EncryptedDataValue {
-    attribute_name: String,
-    value: Vec<u8>,
+    pub(crate) attribute_name: String,
+    pub(crate) value: Vec<u8>,
 }
 
 pub struct IdentifiableDatum {
-    handle: String,
-    data_value: DataValue,
+    pub(crate) handle: String,
+    pub(crate) data_value: DataValue,
 }
 
 pub struct BlindedIdentifiableDatum {
-    handle: BlindedIdentifiableHandle,
-    data_value: EncryptedDataValue,
+    pub(crate) handle: BlindedIdentifiableHandle,
+    pub(crate) data_value: EncryptedDataValue,
 }
 
 pub struct BlindedPseudonymizedDatum {
-    handle: BlindedPseudonymizedHandle,
-    data_value: EncryptedDataValue,
+    pub(crate) handle: BlindedPseudonymizedHandle,
+    pub(crate) data_value: EncryptedDataValue,
 }
 
 pub struct PseudonymizedDatum {
-    handle: Pseudonym,
-    data_value: DataValue,
+    pub(crate) handle: Pseudonym,
+    pub(crate) data_value: DataValue,
 }

--- a/hacspec-scrambledb/scrambledb/src/data_types.rs
+++ b/hacspec-scrambledb/scrambledb/src/data_types.rs
@@ -28,32 +28,32 @@ pub struct EncryptedDataValue {
     pub(crate) attribute_name: String,
 }
 
-pub struct IdentifiableDatum {
 /// An identifiable piece of data.
+pub struct IdentifiableData {
     /// A plain text handle.
     pub(crate) handle: String,
     /// A plain text data value.
     pub(crate) data_value: DataValue,
 }
 
-pub struct BlindedIdentifiableDatum {
 /// The blinded version of an identifiable piece of data.
+pub struct BlindedIdentifiableData {
     /// A blinded plain text handle.
     pub(crate) handle: BlindedIdentifiableHandle,
     /// An encrypted data value.
     pub(crate) data_value: EncryptedDataValue,
 }
 
-pub struct BlindedPseudonymizedDatum {
 /// The blinded version of a pseudonymized piece of data.
+pub struct BlindedPseudonymizedData {
     /// A blinded pseudonymous handle.
     pub(crate) handle: BlindedPseudonymizedHandle,
     /// An encrypted data value.
     pub(crate) data_value: EncryptedDataValue,
 }
 
-pub struct PseudonymizedDatum {
 /// A pseudonymized piece of data.
+pub struct PseudonymizedData {
     /// A pseudonymous handle.
     pub(crate) handle: FinalizedPseudonym,
     /// A plain text data value.

--- a/hacspec-scrambledb/scrambledb/src/error.rs
+++ b/hacspec-scrambledb/scrambledb/src/error.rs
@@ -2,6 +2,7 @@
 pub enum Error {
     RandomnessError,
     CorruptedData,
+    InvalidInput,
 }
 
 impl From<oprf::Error> for Error {

--- a/hacspec-scrambledb/scrambledb/src/finalize.rs
+++ b/hacspec-scrambledb/scrambledb/src/finalize.rs
@@ -31,6 +31,7 @@ pub fn finalize_conversion(
                 data_value: EncryptedDataValue {
                     attribute_name: blinded_table.column().attribute(),
                     value: encrypted_value,
+                    encryption_level: 2u8,
                 },
             };
 

--- a/hacspec-scrambledb/scrambledb/src/finalize.rs
+++ b/hacspec-scrambledb/scrambledb/src/finalize.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     data_transformations::finalize_blinded_datum,
-    data_types::{BlindedPseudonymizedDatum, BlindedPseudonymizedHandle, EncryptedDataValue},
+    data_types::{BlindedPseudonymizedData, BlindedPseudonymizedHandle, EncryptedDataValue},
     error::Error,
     setup::StoreContext,
     table::{Column, ConvertedTable, PseudonymizedTable},
@@ -26,7 +26,7 @@ pub fn finalize_conversion(
         let mut pseudonymized_column_data = Vec::new();
 
         for (blinded_pseudonym, encrypted_value) in blinded_table.column().data() {
-            let blinded_pseudonymized_datum = BlindedPseudonymizedDatum {
+            let blinded_pseudonymized_datum = BlindedPseudonymizedData {
                 handle: BlindedPseudonymizedHandle(blinded_pseudonym),
                 data_value: EncryptedDataValue {
                     attribute_name: blinded_table.column().attribute(),

--- a/hacspec-scrambledb/scrambledb/src/finalize.rs
+++ b/hacspec-scrambledb/scrambledb/src/finalize.rs
@@ -27,8 +27,8 @@ pub fn finalize_conversion(
 
         for (blinded_pseudonym, encrypted_value) in blinded_table.column().data() {
             let blinded_pseudonymized_datum = BlindedPseudonymizedData {
-                handle: BlindedPseudonymizedHandle(blinded_pseudonym),
-                data_value: EncryptedDataValue {
+                blinded_handle: BlindedPseudonymizedHandle(blinded_pseudonym),
+                encrypted_data_value: EncryptedDataValue {
                     attribute_name: blinded_table.column().attribute(),
                     value: encrypted_value,
                     encryption_level: 2u8,

--- a/hacspec-scrambledb/scrambledb/src/join.rs
+++ b/hacspec-scrambledb/scrambledb/src/join.rs
@@ -90,8 +90,8 @@ pub fn prepare_join_conversion(
             )?;
 
             blind_column_data.push((
-                blinded_pseudonymized_datum.handle.0,
-                blinded_pseudonymized_datum.data_value.value,
+                blinded_pseudonymized_datum.blinded_handle.0,
+                blinded_pseudonymized_datum.encrypted_data_value.value,
             ));
         }
 
@@ -136,8 +136,8 @@ pub fn join_conversion(
             let mut converted_data = Vec::new();
             for (blind_identifier, encrypted_value) in blind_column.data() {
                 let blinded_pseudonymized_datum = BlindedPseudonymizedData {
-                    handle: BlindedPseudonymizedHandle(blind_identifier),
-                    data_value: EncryptedDataValue {
+                    blinded_handle: BlindedPseudonymizedHandle(blind_identifier),
+                    encrypted_data_value: EncryptedDataValue {
                         attribute_name: attribute.clone(),
                         value: encrypted_value,
                         encryption_level: 1u8,
@@ -153,8 +153,8 @@ pub fn join_conversion(
                 )?;
 
                 converted_data.push((
-                    blinded_pseudonymized_datum.handle.0,
-                    blinded_pseudonymized_datum.data_value.value,
+                    blinded_pseudonymized_datum.blinded_handle.0,
+                    blinded_pseudonymized_datum.encrypted_data_value.value,
                 ));
             }
             let mut converted_table_column = Column::new(attribute.clone(), converted_data);

--- a/hacspec-scrambledb/scrambledb/src/join.rs
+++ b/hacspec-scrambledb/scrambledb/src/join.rs
@@ -140,6 +140,7 @@ pub fn join_conversion(
                     data_value: EncryptedDataValue {
                         attribute_name: attribute.clone(),
                         value: encrypted_value,
+                        encryption_level: 1u8,
                     },
                 };
                 let blinded_pseudonymized_datum = convert_blinded_datum(

--- a/hacspec-scrambledb/scrambledb/src/join.rs
+++ b/hacspec-scrambledb/scrambledb/src/join.rs
@@ -6,8 +6,8 @@ use oprf::coprf::coprf_setup::BlindingPublicKey;
 use crate::{
     data_transformations::{blind_pseudonymized_datum, convert_blinded_datum},
     data_types::{
-        BlindedPseudonymizedDatum, BlindedPseudonymizedHandle, DataValue, EncryptedDataValue,
-        FinalizedPseudonym, PseudonymizedDatum,
+        BlindedPseudonymizedData, BlindedPseudonymizedHandle, DataValue, EncryptedDataValue,
+        FinalizedPseudonym, PseudonymizedData,
     },
     error::Error,
     setup::{ConverterContext, StoreContext},
@@ -74,7 +74,7 @@ pub fn prepare_join_conversion(
         let mut blind_column_data = Vec::new();
 
         for (pseudonym, value) in table.column().data() {
-            let pseudonymized_datum = PseudonymizedDatum {
+            let pseudonymized_datum = PseudonymizedData {
                 handle: FinalizedPseudonym(pseudonym),
                 data_value: DataValue {
                     attribute_name: table.column().attribute(),
@@ -135,7 +135,7 @@ pub fn join_conversion(
 
             let mut converted_data = Vec::new();
             for (blind_identifier, encrypted_value) in blind_column.data() {
-                let blinded_pseudonymized_datum = BlindedPseudonymizedDatum {
+                let blinded_pseudonymized_datum = BlindedPseudonymizedData {
                     handle: BlindedPseudonymizedHandle(blind_identifier),
                     data_value: EncryptedDataValue {
                         attribute_name: attribute.clone(),

--- a/hacspec-scrambledb/scrambledb/src/lib.rs
+++ b/hacspec-scrambledb/scrambledb/src/lib.rs
@@ -263,3 +263,5 @@ pub mod error;
 //#[cfg(feature = "wasm")]
 //pub mod wasm_demo;
 mod test_util;
+mod data_transformations;
+mod data_types;

--- a/hacspec-scrambledb/scrambledb/src/lib.rs
+++ b/hacspec-scrambledb/scrambledb/src/lib.rs
@@ -269,6 +269,8 @@ pub mod setup;
 pub mod split;
 pub mod join;
 pub mod finalize;
+pub mod data_transformations;
+pub mod data_types;
 
 pub mod error;
 
@@ -277,5 +279,3 @@ pub mod wasm_demo;
 
 #[cfg(test)]
 mod test_util;
-mod data_transformations;
-mod data_types;

--- a/hacspec-scrambledb/scrambledb/src/split.rs
+++ b/hacspec-scrambledb/scrambledb/src/split.rs
@@ -5,7 +5,7 @@ use oprf::coprf::coprf_setup::BlindingPublicKey;
 
 use crate::{
     data_transformations::{blind_identifiable_datum, pseudonymize_blinded_datum},
-    data_types::{BlindedIdentifiableDatum, DataValue, EncryptedDataValue, IdentifiableDatum},
+    data_types::{BlindedIdentifiableData, DataValue, EncryptedDataValue, IdentifiableData},
     error::Error,
     setup::ConverterContext,
     table::{BlindTable, Column, ConvertedTable, PlainTable},
@@ -38,7 +38,7 @@ pub fn prepare_split_conversion(
         let mut blinded_column_data = Vec::new();
 
         for (plaintext_id, plaintext_value) in column.data() {
-            let datum = IdentifiableDatum {
+            let datum = IdentifiableData {
                 handle: plaintext_id,
                 data_value: DataValue {
                     attribute_name: attribute.clone(),
@@ -85,7 +85,7 @@ pub fn split_conversion(
 
         let mut converted_column_data = Vec::new();
         for (blind_identifier, encrypted_value) in blinded_column.data() {
-            let blinded_datum = BlindedIdentifiableDatum {
+            let blinded_datum = BlindedIdentifiableData {
                 handle: crate::data_types::BlindedIdentifiableHandle(blind_identifier),
                 data_value: EncryptedDataValue {
                     attribute_name: attribute.clone(),

--- a/hacspec-scrambledb/scrambledb/src/split.rs
+++ b/hacspec-scrambledb/scrambledb/src/split.rs
@@ -90,6 +90,7 @@ pub fn split_conversion(
                 data_value: EncryptedDataValue {
                     attribute_name: attribute.clone(),
                     value: encrypted_value,
+                    encryption_level: 1u8,
                 },
             };
 

--- a/hacspec-scrambledb/scrambledb/src/split.rs
+++ b/hacspec-scrambledb/scrambledb/src/split.rs
@@ -48,7 +48,10 @@ pub fn prepare_split_conversion(
             let blinded_datum =
                 blind_identifiable_datum(&bpk_receiver, ek_receiver, &datum, randomness)?;
 
-            blinded_column_data.push((blinded_datum.handle.0, blinded_datum.data_value.value));
+            blinded_column_data.push((
+                blinded_datum.blinded_handle.0,
+                blinded_datum.encrypted_data_value.value,
+            ));
         }
         let mut blinded_column = Column::new(attribute, blinded_column_data);
         blinded_column.sort();
@@ -86,8 +89,8 @@ pub fn split_conversion(
         let mut converted_column_data = Vec::new();
         for (blind_identifier, encrypted_value) in blinded_column.data() {
             let blinded_datum = BlindedIdentifiableData {
-                handle: crate::data_types::BlindedIdentifiableHandle(blind_identifier),
-                data_value: EncryptedDataValue {
+                blinded_handle: crate::data_types::BlindedIdentifiableHandle(blind_identifier),
+                encrypted_data_value: EncryptedDataValue {
                     attribute_name: attribute.clone(),
                     value: encrypted_value,
                     encryption_level: 1u8,
@@ -103,8 +106,8 @@ pub fn split_conversion(
             )?;
 
             converted_column_data.push((
-                blinded_pseudonymized_datum.handle.0,
-                blinded_pseudonymized_datum.data_value.value,
+                blinded_pseudonymized_datum.blinded_handle.0,
+                blinded_pseudonymized_datum.encrypted_data_value.value,
             ));
         }
 


### PR DESCRIPTION
As a first step towards a cleaner spec, that can be more closely matched to e.g. the ProVerif model, I've factored out the transformations that need to happen to pairs of identifiers/pseudonyms (I've introduced the term `handle` here) and data values, plain or encrypted.

At the moment it's a bit awkward because the table data structures don't know about these sorts of pairs yet, but that should be fixed together with #18 . 