### PR TITLE
Bare-bones landing page for ATLAS

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,14 +31,9 @@ jobs:
         run: |
           cd hacspec-scrambledb
           cargo doc --no-deps
-          cat > target/doc/index.html <<EOF
-          <!doctype html>
-          <html>
-          <head><meta http-equiv="refresh" content="0; url='scrambledb/index.html'"></head>
-          </html>
-          EOF
           mv target/doc ../docs
-
+          cp ../pages/index.html ../docs/
+          
       - name: Fix permissions
         run: |
           chmod -c -R +rX "docs/" | while read line; do

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,22 @@
+ <!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css" />
+  </head>
+  <body>
+    <h1>BMBF project "ATLAS"</h1>
+    <p>This page collects links to materials created by
+      Cryspen as part of the BMBF research project "ATLAS".</p>
+    <ul>
+      <li><a href="https://cryspen.com/post/scrambledb/"> Cryspen blog
+          post on ScrambleDB, one component of the ATLAS
+          system</li></a>
+      <li><a href="https://cryspen.com/post/scrambledb/demo/index.html">ScrambleDB
+          interactive demo</a></li>
+      <li>Documentation for hacspec specifications of ATLAS components
+        <ul><li><a href="/scrambledb/index.html">ScrambleDB</a></li></ul></li>
+      <li><a href="https://github.com/cryspen/atlas">Source code repository for software artefacts</a></li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
This is a minimal landing page for ATLAS with links to our contributions in the project.

It does not contain any information about what ATLAS or ScrambleDB is, right now, since for the former we will soon be able to link to the projects main website and the latter is addressed in the blog post. Just let me know if I should give more context here anyway.