### PR TITLE
Fix link on landing page

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -15,7 +15,7 @@
       <li><a href="https://cryspen.com/post/scrambledb/demo/index.html">ScrambleDB
           interactive demo</a></li>
       <li>Documentation for hacspec specifications of ATLAS components
-        <ul><li><a href="/scrambledb/index.html">ScrambleDB</a></li></ul></li>
+        <ul><li><a href="/atlas/scrambledb/index.html">ScrambleDB</a></li></ul></li>
       <li><a href="https://github.com/cryspen/atlas">Source code repository for software artefacts</a></li>
     </ul>
   </body>


### PR DESCRIPTION
Tiny fix for the ScrambleDB docs link.