### PR TITLE
Define top-level message types

### DIFF
--- a/mpc-spec/src/lib.rs
+++ b/mpc-spec/src/lib.rs
@@ -10,4 +10,5 @@ pub const COMPUTATIONAL_SECURITY: usize = 128 / 8;
 pub const STATISTICAL_SECURITY: usize = 128 / 8;
 
 pub mod circuit;
+pub mod messages;
 pub mod primitives;

--- a/mpc-spec/src/lib.rs
+++ b/mpc-spec/src/lib.rs
@@ -3,4 +3,10 @@
 //! This crate is an executable specification of an MPC engine based on the
 //! WRK17 protocol.
 
+/// The computational security parameter, in bytes.
+pub const COMPUTATIONAL_SECURITY: usize = 128 / 8;
+
+/// The statistical security parameter, in bytes.
+pub const STATISTICAL_SECURITY: usize = 128 / 8;
+
 pub mod circuit;

--- a/mpc-spec/src/lib.rs
+++ b/mpc-spec/src/lib.rs
@@ -10,3 +10,4 @@ pub const COMPUTATIONAL_SECURITY: usize = 128 / 8;
 pub const STATISTICAL_SECURITY: usize = 128 / 8;
 
 pub mod circuit;
+pub mod primitives;

--- a/mpc-spec/src/messages.rs
+++ b/mpc-spec/src/messages.rs
@@ -62,7 +62,7 @@ pub enum FPreResponse {
 /// - top-level protocol messages
 /// - suprotocol messages (incomplete)
 ///   - messages for the FPre subprotocol
-///   - (not currently) messages for the remaining sub-protocols the implement
+///   - (not currently) messages for the remaining sub-protocols which implement
 ///     FPre
 pub enum MPCMessage {
     /// A garbled AND gate, to be sent to the evaluator

--- a/mpc-spec/src/messages.rs
+++ b/mpc-spec/src/messages.rs
@@ -1,0 +1,87 @@
+//! This module defines message types for the MPC protocol and its sub-protocols.
+use crate::{
+    circuit::WireIndex,
+    primitives::{
+        auth_share::AuthShare,
+        mac::{Mac, MacKey},
+    },
+    COMPUTATIONAL_SECURITY,
+};
+
+/// Messages that must be handled by the preprocessing subprotocol, or ideal functionality.
+pub enum FPreRequest {
+    /// A party initialization request. from the indicated party.
+    Init {
+        /// The requesting party.
+        from: usize,
+    },
+    /// A request for a random authenticated share.
+    Random {
+        /// The requesting party.
+        from: usize,
+    },
+    /// A request for the AND of two shares.
+    And {
+        /// The requesting party.
+        from: usize,
+        /// The first AND input share.
+        lhs: AuthShare,
+        /// The second AND input share.
+        rhs: AuthShare,
+    },
+}
+
+/// Messages that are the outcome of the FPre subprotocol.
+pub enum FPreResponse {
+    /// The response to an `Init` request.
+    Init {
+        /// The receiver of the message.
+        to: usize,
+        /// A fresh global MAC key.
+        global_mac_key: MacKey,
+    },
+    /// The response to a `Random` request.
+    Random {
+        /// The receiver of the message.
+        to: usize,
+        /// A fresh random authenticated bit share.
+        share: AuthShare,
+    },
+    /// The response to an `And` request.
+    And {
+        /// The receiver of the message.
+        to: usize,
+        /// A fresh random authenticated bit share of the AND of the requested shares.
+        and_share: AuthShare,
+    },
+}
+
+/// An overall message type for all messages between parties.
+///
+/// It includes:
+/// - top-level protocol messages
+/// - suprotocol messages (incomplete)
+///   - messages for the FPre subprotocol
+///   - (not currently) messages for the remaining sub-protocols the implement
+///     FPre
+pub enum MPCMessage {
+    /// A garbled AND gate, to be sent to the evaluator
+    GarbledAnd(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>),
+    /// A MAC on a wire mask share
+    WireMac(usize, bool, Mac),
+    /// Masked input wire value
+    MaskedInput(bool),
+    /// A wire label, to be sent to the evaluator
+    WireLabel {
+        /// The originator of the label
+        from: usize,
+        /// The wire the label belongs to
+        wire: WireIndex,
+        /// The wire label
+        label: [u8; COMPUTATIONAL_SECURITY],
+    },
+    /// A message to the FPre subprotocol
+    FPreRequest(FPreRequest),
+    /// The FPre subprotocol response
+    FPreResponse(FPreResponse),
+}

--- a/mpc-spec/src/primitives/auth_share.rs
+++ b/mpc-spec/src/primitives/auth_share.rs
@@ -1,0 +1,13 @@
+//! This module defines the interface for share authentication.
+use super::mac::{Mac, MacKey};
+
+/// An authenticated share of a bit.
+#[allow(dead_code)] // TODO: Remove this later.
+pub struct AuthShare {
+    /// Party i's share of the bit
+    share: bool,
+    /// MACs on the shared bit provided by the other parties
+    macs: Vec<(usize, Mac)>,
+    /// Keys for authenticating the other parties' shares of the bit
+    keys: Vec<(usize, MacKey)>,
+}

--- a/mpc-spec/src/primitives/auth_share.rs
+++ b/mpc-spec/src/primitives/auth_share.rs
@@ -5,9 +5,9 @@ use super::mac::{Mac, MacKey};
 #[allow(dead_code)] // TODO: Remove this later.
 pub struct AuthShare {
     /// Party i's share of the bit
-    share: bool,
+    pub(crate) share: bool,
     /// MACs on the shared bit provided by the other parties
-    macs: Vec<(usize, Mac)>,
+    pub(crate) macs: Vec<(usize, Mac)>,
     /// Keys for authenticating the other parties' shares of the bit
-    keys: Vec<(usize, MacKey)>,
+    pub(crate) keys: Vec<(usize, MacKey)>,
 }

--- a/mpc-spec/src/primitives/mac.rs
+++ b/mpc-spec/src/primitives/mac.rs
@@ -1,0 +1,8 @@
+//! This module defines an information theoretic MAC for authenticating bits.
+
+use crate::COMPUTATIONAL_SECURITY;
+
+/// A MAC on a bit.
+pub type Mac = [u8; COMPUTATIONAL_SECURITY];
+/// A MAC key for authenticating a bit to another party.
+pub type MacKey = [u8; COMPUTATIONAL_SECURITY];

--- a/mpc-spec/src/primitives/mod.rs
+++ b/mpc-spec/src/primitives/mod.rs
@@ -1,0 +1,4 @@
+//! This module provides interfaces for the basic primitives used in WRK17.
+
+pub mod auth_share;
+pub mod mac;


### PR DESCRIPTION
This PR introduces the message types required in the top-level MPC protocol (i.e. subprotocol message types are not yet defined).

I also define some basic data structures which make up the message payloads.