### PR TITLE
Multi-Party bit authentication spec

### DIFF
--- a/atlas-spec/chacha20/tests/test_chacha20.rs
+++ b/atlas-spec/chacha20/tests/test_chacha20.rs
@@ -13,7 +13,7 @@ use hacspec_chacha20::*;
 //         0x2098d9d6, 0x91dbd320,
 //     ]);
 //     state = chacha20_quarter_round(2, 7, 8, 13, state);
-//     assert_eq!(
+//     debug_assert_eq!(
 //         state
 //             .iter()
 //             .map(|x| U32::declassify(*x))
@@ -42,7 +42,7 @@ use hacspec_chacha20::*;
 //         0x0f0e0d0c, 0x13121110, 0x17161514, 0x1b1a1918, 0x1f1e1d1c, 0x00000001, 0x09000000,
 //         0x4a000000, 0x00000000,
 //     ]);
-//     assert_eq!(
+//     debug_assert_eq!(
 //         state
 //             .iter()
 //             .map(|x| U32::declassify(*x))
@@ -59,7 +59,7 @@ use hacspec_chacha20::*;
 //         0x4e6cd4c3, 0x466482d2, 0x09aa9f07, 0x05d7c214, 0xa2028bd9, 0xd19c12b5, 0xb94e16de,
 //         0xe883d0cb, 0x4e3c50a2,
 //     ]);
-//     assert_eq!(
+//     debug_assert_eq!(
 //         state
 //             .iter()
 //             .map(|x| U32::declassify(*x))
@@ -79,7 +79,7 @@ use hacspec_chacha20::*;
 //     ]);
 //     let serialised = state.to_le_bytes();
 //     println!("{:?}", serialised.len());
-//     assert_eq!(
+//     debug_assert_eq!(
 //         serialised
 //             .iter()
 //             .map(|x| U8::declassify(*x))
@@ -94,7 +94,7 @@ use hacspec_chacha20::*;
 // fn enc_dec_test(m: ByteSeq, key: ChaChaKey, iv: ChaChaIV) {
 //     let c = chacha20(key, iv, 1u32, &m);
 //     let m_dec = chacha20(key, iv, 1u32, &c);
-//     assert_eq!(
+//     debug_assert_eq!(
 //         m.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>(),
 //         m_dec.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>()
 //     );
@@ -103,9 +103,9 @@ use hacspec_chacha20::*;
 fn kat_test(m: &[u8], key: ChaChaKey, iv: ChaChaIV, exp_cipher: &[u8]) {
     let enc = chacha20(key, iv, 1u32, &m);
     let c = enc;
-    assert_eq!(exp_cipher, c);
+    debug_assert_eq!(exp_cipher, c);
     let m_dec = chacha20(key, iv, 1u32, &c);
-    assert_eq!(m, m_dec);
+    debug_assert_eq!(m, m_dec);
 }
 
 // #[test]

--- a/atlas-spec/elgamal/src/lib.rs
+++ b/atlas-spec/elgamal/src/lib.rs
@@ -132,7 +132,7 @@ mod test {
         let ctx = encrypt(ek, msg, &mut Randomness::new(vec![0xab; 32])).unwrap();
         let decryption = decrypt(dk, ctx).unwrap();
 
-        assert_eq!(msg, decryption);
+        debug_assert_eq!(msg, decryption);
     }
 
     #[test]
@@ -148,7 +148,7 @@ mod test {
         let rctx = rerandomize(ek, ctx, &mut Randomness::new(vec![0xab; 32])).unwrap();
         let decryption = decrypt(dk, rctx).unwrap();
 
-        assert_eq!(msg, decryption);
+        debug_assert_eq!(msg, decryption);
         assert_ne!(ctx, rctx);
     }
 

--- a/atlas-spec/hacspec-chacha20poly1305/tests/test_chacha20poly1305.rs
+++ b/atlas-spec/hacspec-chacha20poly1305/tests/test_chacha20poly1305.rs
@@ -37,13 +37,13 @@ fn kat() {
         0x91,
     ];
     let (cipher, mac) = chacha20_poly1305_encrypt(k, iv, &aad, &msg);
-    assert_eq!(exp_cipher.to_vec(), cipher);
-    assert_eq!(exp_mac, mac);
+    debug_assert_eq!(exp_cipher.to_vec(), cipher);
+    debug_assert_eq!(exp_mac, mac);
     let decrypted_msg = match chacha20_poly1305_decrypt(k, iv, &aad, &cipher, mac) {
         Ok(m) => m,
         Err(_) => panic!("Error decrypting"),
     };
-    assert_eq!(msg.to_vec(), decrypted_msg);
+    debug_assert_eq!(msg.to_vec(), decrypted_msg);
 }
 
 #[test]

--- a/atlas-spec/hacspec_lib/src/hacspec_helper.rs
+++ b/atlas-spec/hacspec_lib/src/hacspec_helper.rs
@@ -202,7 +202,7 @@ pub trait NatMod<const LEN: usize> {
     where
         Self: Sized,
     {
-        assert!(hex.len() % 2 == 0);
+        debug_assert!(hex.len() % 2 == 0);
         let l = hex.len() / 2;
         let mut value = vec![0u8; l];
         for i in 0..l {
@@ -226,7 +226,7 @@ pub trait NatMod<const LEN: usize> {
         Self: Sized,
     {
         let max_value = Self::MODULUS;
-        assert!(
+        debug_assert!(
             x <= num_bigint::BigUint::from_bytes_be(&max_value),
             "{} is too large for type {}!",
             x,

--- a/atlas-spec/hacspec_lib/src/lib.rs
+++ b/atlas-spec/hacspec_lib/src/lib.rs
@@ -34,7 +34,7 @@ pub fn i2osp(value: usize, len: usize) -> Vec<u8> {
 }
 
 pub fn xor_slice(mut this: Vec<u8>, other: &[u8]) -> Vec<u8> {
-    assert!(this.len() == other.len());
+    debug_assert!(this.len() == other.len());
 
     // error[CE0008]: (Diagnostics.Context.Phase (Reject ArbitraryLhs)): ExplicitRejection { reason: "unknown reason" }
     //  --> hmac-rust/src/hacspec_helper.rs:5:9
@@ -53,7 +53,7 @@ pub fn xor_slice(mut this: Vec<u8>, other: &[u8]) -> Vec<u8> {
 macro_rules! to_le_u32s_impl {
     ($name:ident,$l:literal) => {
         pub fn $name(bytes: &[u8]) -> [u32; $l] {
-            assert_eq!($l, bytes.len() / 4);
+            debug_assert_eq!($l, bytes.len() / 4);
             let mut out = [0; $l];
             for i in 0..$l {
                 out[i] = u32::from_le_bytes(bytes[4 * i..4 * i + 4].try_into().unwrap());
@@ -92,7 +92,7 @@ pub fn add_state(mut state: [u32; 16], other: [u32; 16]) -> [u32; 16] {
 }
 
 pub fn update_array(mut array: [u8; 64], val: &[u8]) -> [u8; 64] {
-    assert!(64 >= val.len());
+    debug_assert!(64 >= val.len());
     array[..val.len()].copy_from_slice(val);
     array
 }

--- a/atlas-spec/hash-to-curve/src/p256_hash.rs
+++ b/atlas-spec/hash-to-curve/src/p256_hash.rs
@@ -57,7 +57,7 @@ fn expand_message(msg: &[u8], dst: &[u8], len_in_bytes: usize) -> Result<Vec<u8>
 }
 
 fn strxor(a: &[u8], b: &[u8]) -> Vec<u8> {
-    assert_eq!(a.len(), b.len());
+    debug_assert_eq!(a.len(), b.len());
     a.iter().zip(b.iter()).map(|(a, b)| a ^ b).collect()
 }
 
@@ -149,7 +149,7 @@ mod tests {
         let tests = load_vectors(vector_path.as_path());
         let dst = tests["dst"].as_str().unwrap().as_bytes();
 
-        //assert_eq!(tests["ciphersuite"].as_str().unwrap(), ID);
+        //debug_assert_eq!(tests["ciphersuite"].as_str().unwrap(), ID);
 
         for test_case in tests["vectors"].as_array().unwrap().iter() {
             let msg_str = test_case["msg"].as_str().unwrap();
@@ -167,9 +167,9 @@ mod tests {
                 .collect();
 
             let u_real = hash_to_field(msg, dst, 2).unwrap();
-            assert_eq!(u_real.len(), u_expected.len());
+            debug_assert_eq!(u_real.len(), u_expected.len());
             for (u_real, u_expected) in u_real.iter().zip(u_expected.iter()) {
-                assert_eq!(
+                debug_assert_eq!(
                     u_expected.as_ref(),
                     u_real.as_ref(),
                     "u0 did not match for {msg_str}",
@@ -211,11 +211,11 @@ mod tests {
             let q1_y_expected =
                 P256FieldElement::from_be_bytes(&hex::decode(q1_y_expected).unwrap());
 
-            assert_eq!(q0_x_expected, q0_x, "x0 incorrect");
-            assert_eq!(q0_y_expected, q0_y, "y0 incorrect");
+            debug_assert_eq!(q0_x_expected, q0_x, "x0 incorrect");
+            debug_assert_eq!(q0_y_expected, q0_y, "y0 incorrect");
 
-            assert_eq!(q1_x_expected, q1_x, "x1 incorrect");
-            assert_eq!(q1_y_expected, q1_y, "y1 incorrect");
+            debug_assert_eq!(q1_x_expected, q1_x, "x1 incorrect");
+            debug_assert_eq!(q1_y_expected, q1_y, "y1 incorrect");
         }
     }
 
@@ -241,9 +241,9 @@ mod tests {
 
             let (x, y) = hash_to_curve(msg, dst).unwrap().into();
 
-            // assert!(!inf, "Point should not be infinite");
-            assert_eq!(p_x_expected.as_ref(), x.as_ref(), "x-coordinate incorrect");
-            assert_eq!(p_y_expected.as_ref(), y.as_ref(), "y-coordinate incorrect");
+            // debug_assert!(!inf, "Point should not be infinite");
+            debug_assert_eq!(p_x_expected.as_ref(), x.as_ref(), "x-coordinate incorrect");
+            debug_assert_eq!(p_y_expected.as_ref(), y.as_ref(), "y-coordinate incorrect");
         }
     }
 }

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -1,4 +1,4 @@
-use std::thread;
+use std::{sync::BarrierWaitResult, thread};
 
 use hacspec_lib::Randomness;
 use mpc_engine::circuit::{Circuit, WiredGate};
@@ -24,7 +24,9 @@ fn main() {
     let num_parties = circuit.number_of_parties();
 
     // Set up channels
-    let mut party_channels = mpc_engine::utils::set_up_channels(num_parties);
+    let (broadcast_relay, mut party_channels) = mpc_engine::utils::set_up_channels(num_parties);
+
+    let _ = thread::spawn(move || broadcast_relay.run());
 
     let mut party_join_handles = Vec::new();
     for _i in 0..num_parties {

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -1,4 +1,4 @@
-use std::{sync::BarrierWaitResult, thread};
+use std::thread;
 
 use hacspec_lib::Randomness;
 use mpc_engine::circuit::{Circuit, WiredGate};
@@ -36,10 +36,11 @@ fn main() {
         let c = circuit.clone();
         let party_join_handle = thread::spawn(move || {
             let mut rng = rand::thread_rng();
-            let mut bytes = vec![0u8; 500];
+            let mut bytes = vec![0u8; u16::MAX.try_into().unwrap()];
             rng.fill_bytes(&mut bytes);
             let rng = Randomness::new(bytes);
-            let mut p = mpc_engine::party::Party::new(channel_config, &c, rng);
+            let log_enabled = channel_config.id == 1;
+            let mut p = mpc_engine::party::Party::new(channel_config, &c, log_enabled, rng);
 
             let _ = p.run();
         });

--- a/atlas-spec/mpc-engine/src/broadcast.rs
+++ b/atlas-spec/mpc-engine/src/broadcast.rs
@@ -39,7 +39,7 @@ impl BroadcastRelay {
     /// shut down and dropped their copies of the sender. In this case the
     /// broadcast relay also shuts down.
     pub fn run(&self) {
-        'outer: loop {
+        loop {
             let mut openings = Vec::new();
             for _i in 0..self.num_parties {
                 let opening_msg = self.listen.recv();
@@ -55,7 +55,7 @@ impl BroadcastRelay {
                     openings.push(opening_msg.expect("already confirmed it's ok"))
                 } else {
                     // One of the parties was dropped, time to shut down.
-                    break 'outer;
+                    return;
                 }
             }
 

--- a/atlas-spec/mpc-engine/src/broadcast.rs
+++ b/atlas-spec/mpc-engine/src/broadcast.rs
@@ -1,0 +1,67 @@
+//! This module implements a stateless broadcast relay.
+
+use std::sync::mpsc::{Receiver, Sender};
+
+use crate::messages::{Message, MessagePayload};
+
+/// A stateless broadcast relay functionality.
+///
+/// Accepts openings to broadcasted committed values and relays them to all
+/// parties.
+pub struct BroadcastRelay {
+    num_parties: usize,
+    pub(crate) listen: Receiver<Message>,
+    pub(crate) parties: Vec<Sender<Message>>,
+}
+
+impl BroadcastRelay {
+    /// Create a new broadcast relay.
+    pub fn new(listen: Receiver<Message>, parties: Vec<Sender<Message>>) -> Self {
+        Self {
+            num_parties: parties.len(),
+            listen,
+            parties,
+        }
+    }
+
+    /// Continuously await broadcast communication rounds.
+    pub fn run(&self) {
+        'outer: loop {
+            let mut openings = Vec::new();
+            for _i in 0..self.num_parties {
+                let opening_msg = self.listen.recv();
+                if let Ok(Message {
+                    from,
+                    to,
+                    payload: MessagePayload::BroadcastOpening(_),
+                }) = opening_msg
+                {
+                    if from != to {
+                        panic!("Malformed broadcast opening")
+                    }
+                    openings.push(opening_msg.expect("already confirmed it's ok"))
+                } else {
+                    // One of the parties was dropped, time to shut down.
+                    break 'outer;
+                }
+            }
+
+            for opening in openings {
+                for i in 0..self.num_parties {
+                    if i == opening.from {
+                        continue;
+                    }
+
+                    if let MessagePayload::BroadcastOpening(ref inner_opening) = opening.payload {
+                        let franked_opening = Message {
+                            from: opening.from,
+                            to: i,
+                            payload: MessagePayload::BroadcastOpening(inner_opening.clone()),
+                        };
+                        self.parties[i].send(franked_opening).unwrap();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/atlas-spec/mpc-engine/src/broadcast.rs
+++ b/atlas-spec/mpc-engine/src/broadcast.rs
@@ -49,9 +49,7 @@ impl BroadcastRelay {
                     payload: MessagePayload::BroadcastOpening(_),
                 }) = opening_msg
                 {
-                    if from != to {
-                        panic!("Malformed broadcast opening")
-                    }
+                    debug_assert_eq!(from, to, "malformed broadcast opening");
                     openings.push(opening_msg.expect("already confirmed it's ok"))
                 } else {
                     // One of the parties was dropped, time to shut down.
@@ -71,7 +69,9 @@ impl BroadcastRelay {
                             to: i,
                             payload: MessagePayload::BroadcastOpening(inner_opening.clone()),
                         };
-                        self.parties[i].send(franked_opening).unwrap();
+                        self.parties[i].send(franked_opening).expect(
+                            "all parties should still be online, waiting to receive the opening",
+                        );
                     }
                 }
             }

--- a/atlas-spec/mpc-engine/src/lib.rs
+++ b/atlas-spec/mpc-engine/src/lib.rs
@@ -62,6 +62,9 @@ pub const COMPUTATIONAL_SECURITY: usize = 128 / 8;
 /// The statistical security parameter, in bytes.
 pub const STATISTICAL_SECURITY: usize = 128 / 8;
 
+// NOTE: The `broadcast` module implements a broadcast utility via a trusted
+// third-party message relay, in lieu of a secure peer-to-peer broadcast
+// sub-protocol.
 pub mod broadcast;
 pub mod circuit;
 pub mod messages;

--- a/atlas-spec/mpc-engine/src/lib.rs
+++ b/atlas-spec/mpc-engine/src/lib.rs
@@ -56,6 +56,7 @@ pub const COMPUTATIONAL_SECURITY: usize = 128 / 8;
 /// The statistical security parameter, in bytes.
 pub const STATISTICAL_SECURITY: usize = 128 / 8;
 
+pub mod broadcast;
 pub mod circuit;
 pub mod messages;
 pub mod party;

--- a/atlas-spec/mpc-engine/src/lib.rs
+++ b/atlas-spec/mpc-engine/src/lib.rs
@@ -20,8 +20,6 @@ use messages::{Message, SubMessage};
 /// if possible remove the cheater in a secure way, so these errors should be
 /// handled there.
 pub enum Error {
-    /// More random bytes have been asked for than are available.
-    InsufficientRandomness,
     /// An error during circuit processing
     Circuit(CircuitError),
     /// A specific subprotocol message was expected but a different one was
@@ -40,22 +38,9 @@ pub enum Error {
     OtherError,
 }
 
-impl From<hacspec_lib::Error> for Error {
-    fn from(value: hacspec_lib::Error) -> Self {
-        match value {
-            hacspec_lib::Error::InsufficientRandomness => Self::InsufficientRandomness,
-        }
-    }
-}
-
 impl From<p256::Error> for Error {
-    fn from(value: p256::Error) -> Self {
-        match value {
-            p256::Error::InvalidAddition
-            | p256::Error::DeserializeError
-            | p256::Error::PointAtInfinity => Self::CurveError,
-            p256::Error::SamplingError => Self::InsufficientRandomness,
-        }
+    fn from(_value: p256::Error) -> Self {
+        Self::CurveError
     }
 }
 

--- a/atlas-spec/mpc-engine/src/lib.rs
+++ b/atlas-spec/mpc-engine/src/lib.rs
@@ -19,6 +19,12 @@ pub enum Error {
     /// A specific top-level message was expected but a different one was
     /// received
     UnexpectedMessage(Message),
+    /// Failed to open a commitment
+    BadCommitment(Vec<u8>, Vec<u8>),
+    /// Error from the curve implementation
+    CurveError,
+    /// Error from the AEAD
+    AEADError,
     /// Miscellaneous error.
     OtherError,
 }
@@ -36,7 +42,7 @@ impl From<p256::Error> for Error {
         match value {
             p256::Error::InvalidAddition
             | p256::Error::DeserializeError
-            | p256::Error::PointAtInfinity => Self::OtherError,
+            | p256::Error::PointAtInfinity => Self::CurveError,
             p256::Error::SamplingError => Self::InsufficientRandomness,
         }
     }
@@ -45,7 +51,7 @@ impl From<p256::Error> for Error {
 impl From<hacspec_chacha20poly1305::Error> for Error {
     fn from(value: hacspec_chacha20poly1305::Error) -> Self {
         match value {
-            hacspec_chacha20poly1305::Error::InvalidTag => Self::OtherError,
+            hacspec_chacha20poly1305::Error::InvalidTag => Self::AEADError,
         }
     }
 }

--- a/atlas-spec/mpc-engine/src/lib.rs
+++ b/atlas-spec/mpc-engine/src/lib.rs
@@ -8,6 +8,17 @@ use messages::{Message, SubMessage};
 
 #[derive(Debug)]
 /// An error type.
+///
+/// We generally expect to definitely panic in two cases:
+/// * Insufficient randomness was provided for a given operation
+/// * A channel handle was prematurely dropped (this indicates a bug in the
+///   specification)
+///
+/// In other cases, the errors might be the result of a buggy protocol
+/// participant, or a detected attempt at cheating. These cases should be
+/// handled by the surrounding application in order to gracefully shut down or,
+/// if possible remove the cheater in a secure way, so these errors should be
+/// handled there.
 pub enum Error {
     /// More random bytes have been asked for than are available.
     InsufficientRandomness,

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -30,6 +30,10 @@ pub struct Message {
 /// protocol.
 #[derive(Debug)]
 pub enum MessagePayload {
+    /// A commitment on a random value for the coin-flipping subprotocol.
+    RandCommitment(Commitment),
+    /// The opening in the coin flipping subprotocol.
+    RandOpening(Opening),
     /// A subchannel for running an 2-party subprotocol.
     SubChannel(Sender<SubMessage>, Receiver<SubMessage>),
     /// A garbled AND gate, to be sent to the evaluator

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -35,10 +35,10 @@ pub enum MessagePayload {
     RequestBitAuth(BitID),
     /// A response to a bit authentication request.
     BitAuth(BitID, Mac),
-    /// A commitment on a random value for the coin-flipping subprotocol.
-    RandCommitment(Commitment),
-    /// The opening in the coin flipping subprotocol.
-    RandOpening(Opening),
+    /// A commitment on a broadcast value.
+    BroadcastCommitment(Commitment),
+    /// The opening to a broadcast value.
+    BroadcastOpening(Opening),
     /// A subchannel for running an 2-party subprotocol.
     SubChannel(Sender<SubMessage>, Receiver<SubMessage>),
     /// A garbled AND gate, to be sent to the evaluator

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc::{Receiver, Sender};
 use crate::{
     circuit::WireIndex,
     primitives::{
-        auth_share::{AuthBit, BitID},
+        auth_share::BitID,
         commitment::{Commitment, Opening},
         mac::Mac,
         ot::{OTReceiverSelect, OTSenderInit, OTSenderSend},
@@ -31,8 +31,10 @@ pub struct Message {
 /// protocol.
 #[derive(Debug)]
 pub enum MessagePayload {
+    /// A round synchronization message
+    Sync,
     /// Request a number of bit authentications from another party.
-    RequestBitAuth(BitID),
+    RequestBitAuth(BitID, Sender<SubMessage>, Receiver<SubMessage>),
     /// A response to a bit authentication request.
     BitAuth(BitID, Mac),
     /// A commitment on a broadcast value.
@@ -41,6 +43,8 @@ pub enum MessagePayload {
     BroadcastOpening(Opening),
     /// A subchannel for running an 2-party subprotocol.
     SubChannel(Sender<SubMessage>, Receiver<SubMessage>),
+    /// A bit mac for validity checking
+    Mac(Mac),
     /// A garbled AND gate, to be sent to the evaluator
     GarbledAnd(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>),
     /// A MAC on a wire mask share

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -4,6 +4,7 @@ use std::sync::mpsc::{Receiver, Sender};
 use crate::{
     circuit::WireIndex,
     primitives::{
+        auth_share::{AuthBit, BitID},
         commitment::{Commitment, Opening},
         mac::Mac,
         ot::{OTReceiverSelect, OTSenderInit, OTSenderSend},
@@ -30,6 +31,10 @@ pub struct Message {
 /// protocol.
 #[derive(Debug)]
 pub enum MessagePayload {
+    /// Request a number of bit authentications from another party.
+    RequestBitAuth(BitID),
+    /// A response to a bit authentication request.
+    BitAuth(BitID, Mac),
     /// A commitment on a random value for the coin-flipping subprotocol.
     RandCommitment(Commitment),
     /// The opening in the coin flipping subprotocol.

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -63,5 +63,5 @@ pub enum SubMessage {
     /// An EQ responder message
     EQResponse(Vec<u8>),
     /// An EQ initiator opening
-    EQOpening(Vec<u8>, Opening),
+    EQOpening(Opening),
 }

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -215,7 +215,7 @@ impl Party {
     /// After this point the guarantee is that a pair-wise consistent
     /// `global_mac_key` was used in all bit-authentications between two
     /// parties.
-    fn mutliparty_authenticate(&mut self, len: usize) -> Result<Vec<AuthBit>, Error> {
+    fn multiparty_authenticate(&mut self, len: usize) -> Result<Vec<AuthBit>, Error> {
         let len_unchecked = len + 2 * STATISTICAL_SECURITY * 8;
 
         // 1. Generate `len_unchecked` random local bits for authenticating.
@@ -667,7 +667,7 @@ impl Party {
 
     /// Run the MPC protocol, returning the parties output, if any.
     pub fn run(&mut self) -> Result<Option<Vec<bool>>, Error> {
-        let _auth_bits = self.mutliparty_authenticate(1)?;
+        let _auth_bits = self.multiparty_authenticate(1)?;
 
         Ok(None)
     }

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -239,9 +239,7 @@ impl Party {
         let responder_message = own_receiver.recv().unwrap();
         if let SubMessage::EQResponse(their_value) = responder_message {
             let res = their_value == my_value;
-            their_sender
-                .send(SubMessage::EQOpening(my_value.to_vec(), opening))
-                .unwrap();
+            their_sender.send(SubMessage::EQOpening(opening)).unwrap();
             Ok(res)
         } else {
             Err(Error::UnexpectedSubprotocolMessage(responder_message))
@@ -268,8 +266,9 @@ impl Party {
                     .send(SubMessage::EQResponse(my_value.to_vec()))
                     .unwrap();
                 let opening_message = my_channel.recv().unwrap();
-                if let SubMessage::EQOpening(their_value, opening) = opening_message {
-                    Ok(commitment.open(&their_value, &opening).is_ok() && my_value == their_value)
+                if let SubMessage::EQOpening(opening) = opening_message {
+                    let their_value = commitment.open(&opening)?;
+                    Ok(my_value == their_value)
                 } else {
                     Err(Error::UnexpectedSubprotocolMessage(opening_message))
                 }

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -129,7 +129,7 @@ impl Party {
             let commitment_msg = self.channels.listen.recv().unwrap();
             if let MessagePayload::BroadcastCommitment(received_commitment) = commitment_msg.payload
             {
-                assert_eq!(commitment_msg.to, self.id);
+                debug_assert_eq!(commitment_msg.to, self.id);
                 received_commitments.push((commitment_msg.from, received_commitment));
             } else {
                 return Err(Error::UnexpectedMessage(commitment_msg));
@@ -157,7 +157,7 @@ impl Party {
             let commitment_msg = self.channels.listen.recv().unwrap();
             if let MessagePayload::BroadcastCommitment(received_commitment) = commitment_msg.payload
             {
-                assert_eq!(commitment_msg.to, self.id);
+                debug_assert_eq!(commitment_msg.to, self.id);
                 received_commitments.push((commitment_msg.from, received_commitment));
             } else {
                 return Err(Error::UnexpectedMessage(commitment_msg));
@@ -302,7 +302,7 @@ impl Party {
 
             let mut other_x_js = Vec::new();
             for (party, other_x_j) in other_x_j_bytes {
-                assert!(other_x_j.len() == 1);
+                debug_assert!(other_x_j.len() == 1);
                 other_x_js.push((party, other_x_j[0] != 0))
             }
 
@@ -344,7 +344,7 @@ impl Party {
             for _i in 0..self.id {
                 let mac_message = self.channels.listen.recv().unwrap();
                 if let MessagePayload::Mac(mac) = mac_message.payload {
-                    assert_eq!(mac_message.to, self.id, "Wrong recipient for MAC message");
+                    debug_assert_eq!(mac_message.to, self.id, "Wrong recipient for MAC message");
                     received_macs.push((mac_message.from, mac));
                 } else {
                     return Err(Error::UnexpectedMessage(mac_message));
@@ -369,7 +369,7 @@ impl Party {
             for _i in self.id + 1..self.num_parties {
                 let mac_message = self.channels.listen.recv().unwrap();
                 if let MessagePayload::Mac(mac) = mac_message.payload {
-                    assert_eq!(mac_message.to, self.id, "Wrong recipient for MAC message");
+                    debug_assert_eq!(mac_message.to, self.id, "Wrong recipient for MAC message");
                     received_macs.push((mac_message.from, mac));
                 } else {
                     return Err(Error::UnexpectedMessage(mac_message));
@@ -409,7 +409,7 @@ impl Party {
 
         let mut result = my_contribution;
         for (_party, their_contribution) in other_contributions {
-            assert_eq!(
+            debug_assert_eq!(
                 their_contribution.len(),
                 result.len(),
                 "all randomness contributions must be of the same length"
@@ -530,7 +530,7 @@ impl Party {
             payload: MessagePayload::SubChannel(their_channel, my_channel),
         } = channel_msg
         {
-            assert_eq!(to, self.id);
+            debug_assert_eq!(to, self.id);
             let commit_message = my_channel.recv().unwrap();
             if let SubMessage::EQCommit(commitment) = commit_message {
                 their_channel
@@ -619,7 +619,7 @@ impl Party {
             payload: MessagePayload::RequestBitAuth(holder_bit_id, their_address, my_inbox),
         } = request_msg
         {
-            assert_eq!(to, self.id, "Got a wrongly addressed message");
+            debug_assert_eq!(to, self.id, "Got a wrongly addressed message");
 
             // Compute the MACs for both possible values of the bit holder's
             // bit. Note that `mac_on_false` is simply the fresh local mac_key.

--- a/atlas-spec/mpc-engine/src/primitives/auth_share.rs
+++ b/atlas-spec/mpc-engine/src/primitives/auth_share.rs
@@ -24,6 +24,7 @@ pub struct AuthBit {
 
 /// The key to authenticate a two-party authenticated bit.
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // TODO: remove this later
 pub struct BitKey {
     pub(crate) id: BitID,
     pub(crate) bit_holder: usize,

--- a/atlas-spec/mpc-engine/src/primitives/auth_share.rs
+++ b/atlas-spec/mpc-engine/src/primitives/auth_share.rs
@@ -24,7 +24,6 @@ pub struct AuthBit {
 
 /// The key to authenticate a two-party authenticated bit.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // TODO: remove this later
 pub struct BitKey {
     pub(crate) holder_bit_id: BitID,
     pub(crate) bit_holder: usize,

--- a/atlas-spec/mpc-engine/src/primitives/auth_share.rs
+++ b/atlas-spec/mpc-engine/src/primitives/auth_share.rs
@@ -19,14 +19,14 @@ pub struct BitID(pub(crate) usize);
 pub struct AuthBit {
     pub(crate) bit: Bit,
     pub(crate) macs: Vec<(usize, Mac)>,
-    pub(crate) authenticators: Vec<BitKey>,
+    pub(crate) mac_keys: Vec<BitKey>,
 }
 
 /// The key to authenticate a two-party authenticated bit.
 #[derive(Debug, Clone)]
 #[allow(dead_code)] // TODO: remove this later
 pub struct BitKey {
-    pub(crate) id: BitID,
+    pub(crate) holder_bit_id: BitID,
     pub(crate) bit_holder: usize,
     pub(crate) mac_key: MacKey,
 }

--- a/atlas-spec/mpc-engine/src/primitives/auth_share.rs
+++ b/atlas-spec/mpc-engine/src/primitives/auth_share.rs
@@ -1,13 +1,31 @@
 //! This module defines the interface for share authentication.
 use super::mac::{Mac, MacKey};
 
-/// An authenticated share of a bit.
-#[allow(dead_code)] // TODO: Remove this later.
-pub struct AuthShare {
-    /// Party i's share of the bit
-    pub(crate) share: bool,
-    /// MACs on the shared bit provided by the other parties
+/// A bit held by a party with a given ID.
+#[derive(Debug, Clone)]
+pub struct Bit {
+    pub(crate) id: BitID,
+    pub(crate) value: bool,
+}
+#[derive(Debug, Clone)]
+/// A bit identifier.
+///
+/// This is unique per party, not globally, so if referring bits held by another
+/// party, their party ID is also required to disambiguate.
+pub struct BitID(pub(crate) usize);
+
+#[derive(Debug, Clone)]
+/// A bit authenticated between two parties.
+pub struct AuthBit {
+    pub(crate) bit: Bit,
     pub(crate) macs: Vec<(usize, Mac)>,
-    /// Keys for authenticating the other parties' shares of the bit
-    pub(crate) keys: Vec<(usize, MacKey)>,
+    pub(crate) authenticators: Vec<BitKey>,
+}
+
+/// The key to authenticate a two-party authenticated bit.
+#[derive(Debug, Clone)]
+pub struct BitKey {
+    pub(crate) id: BitID,
+    pub(crate) bit_holder: usize,
+    pub(crate) mac_key: MacKey,
 }

--- a/atlas-spec/mpc-engine/src/primitives/commitment.rs
+++ b/atlas-spec/mpc-engine/src/primitives/commitment.rs
@@ -85,6 +85,6 @@ fn simple() {
     let (commitment, opening) = Commitment::new(value, dst, &mut entropy).unwrap();
     let (_another_commitment, another_opening) =
         Commitment::new(another_value, dst, &mut entropy).unwrap();
-    assert!(commitment.open(&opening).is_ok());
-    assert!(commitment.open(&another_opening).is_err());
+    debug_assert!(commitment.open(&opening).is_ok());
+    debug_assert!(commitment.open(&another_opening).is_err());
 }

--- a/atlas-spec/mpc-engine/src/primitives/commitment.rs
+++ b/atlas-spec/mpc-engine/src/primitives/commitment.rs
@@ -62,7 +62,7 @@ impl Commitment {
         ikm.extend_from_slice(&opening.open);
         let com = hkdf_extract(&self.dst, &ikm);
         if self.com != com {
-            return Err(Error::OtherError);
+            return Err(Error::BadCommitment(self.com.clone(), com));
         }
         Ok(opening.value.to_vec())
     }

--- a/atlas-spec/mpc-engine/src/primitives/mac.rs
+++ b/atlas-spec/mpc-engine/src/primitives/mac.rs
@@ -14,8 +14,8 @@ pub type MacKey = [u8; MAC_LENGTH];
 
 /// Generate a fresh MAC key.
 pub fn generate_mac_key(entropy: &mut Randomness) -> Result<MacKey, Error> {
-    let k: [u8; 16] = entropy
-        .bytes(COMPUTATIONAL_SECURITY)?
+    let k: [u8; MAC_LENGTH] = entropy
+        .bytes(MAC_LENGTH)?
         .try_into()
         .map_err(|_| Error::OtherError)?;
     Ok(k)
@@ -27,20 +27,20 @@ pub fn mac(
     global_key: &MacKey,
     entropy: &mut Randomness,
 ) -> Result<(Mac, MacKey), Error> {
-    let k: [u8; 16] = generate_mac_key(entropy)?;
+    let key: [u8; MAC_LENGTH] = generate_mac_key(entropy)?;
 
-    let mut mac = [0u8; COMPUTATIONAL_SECURITY];
+    let mut mac = [0u8; MAC_LENGTH];
     for idx in 0..mac.len() {
-        mac[idx] = k[idx] ^ (if *bit { global_key[idx] } else { 0xff });
+        mac[idx] = key[idx] ^ (if *bit { global_key[idx] } else { 0x00 });
     }
 
-    Ok((mac, k))
+    Ok((mac, key))
 }
 
 /// Verify a MAC on a given bit.
 pub fn verify_mac(bit: &bool, mac: &Mac, key: &MacKey, global_key: &MacKey) -> bool {
     for idx in 0..mac.len() {
-        let recomputed = key[idx] ^ (if *bit { global_key[idx] } else { 0xff });
+        let recomputed = key[idx] ^ (if *bit { global_key[idx] } else { 0x00 });
         if mac[idx] != recomputed {
             return false;
         }

--- a/atlas-spec/mpc-engine/src/primitives/mac.rs
+++ b/atlas-spec/mpc-engine/src/primitives/mac.rs
@@ -1,8 +1,62 @@
 //! This module defines an information theoretic MAC for authenticating bits.
 
-use crate::COMPUTATIONAL_SECURITY;
+use hacspec_lib::Randomness;
+
+use crate::{Error, COMPUTATIONAL_SECURITY};
 
 /// A MAC on a bit.
 pub type Mac = [u8; COMPUTATIONAL_SECURITY];
 /// A MAC key for authenticating a bit to another party.
 pub type MacKey = [u8; COMPUTATIONAL_SECURITY];
+
+/// Generate a fresh MAC key.
+pub fn generate_mac_key(entropy: &mut Randomness) -> Result<MacKey, Error> {
+    let k: [u8; 16] = entropy
+        .bytes(COMPUTATIONAL_SECURITY)?
+        .try_into()
+        .map_err(|_| Error::OtherError)?;
+    Ok(k)
+}
+
+/// Authenticate a bit using the global MAC key.
+pub fn mac(
+    bit: &bool,
+    global_key: &MacKey,
+    entropy: &mut Randomness,
+) -> Result<(Mac, MacKey), Error> {
+    let k: [u8; 16] = generate_mac_key(entropy)?;
+
+    let mut mac = [0u8; COMPUTATIONAL_SECURITY];
+    for idx in 0..mac.len() {
+        mac[idx] = k[idx] ^ (if *bit { global_key[idx] } else { 0xff });
+    }
+
+    Ok((mac, k))
+}
+
+/// Verify a MAC on a given bit.
+pub fn verify_mac(bit: &bool, mac: &Mac, key: &MacKey, global_key: &MacKey) -> bool {
+    for idx in 0..mac.len() {
+        let recomputed = key[idx] ^ (if *bit { global_key[idx] } else { 0xff });
+        if mac[idx] != recomputed {
+            return false;
+        }
+    }
+    true
+}
+
+#[test]
+fn simple() {
+    use rand::thread_rng;
+    use rand::RngCore;
+    let mut rng = thread_rng();
+    let mut random = vec![0; 2 * COMPUTATIONAL_SECURITY + 1];
+    rng.fill_bytes(&mut random);
+    let mut entropy = Randomness::new(random);
+
+    let b = entropy.bit().unwrap();
+    let delta = generate_mac_key(&mut entropy).unwrap();
+    let (mac, key) = mac(&b, &delta, &mut entropy).unwrap();
+    assert!(verify_mac(&b, &mac, &key, &delta));
+    assert!(!verify_mac(&!b, &mac, &key, &delta))
+}

--- a/atlas-spec/mpc-engine/src/primitives/mac.rs
+++ b/atlas-spec/mpc-engine/src/primitives/mac.rs
@@ -31,7 +31,7 @@ pub fn mac(
 
     let mut mac = [0u8; MAC_LENGTH];
     for idx in 0..mac.len() {
-        mac[idx] = key[idx] ^ (if *bit { global_key[idx] } else { 0x00 });
+        mac[idx] = key[idx] ^ (*bit as u8) * global_key[idx];
     }
 
     Ok((mac, key))
@@ -40,7 +40,7 @@ pub fn mac(
 /// Verify a MAC on a given bit.
 pub fn verify_mac(bit: &bool, mac: &Mac, key: &MacKey, global_key: &MacKey) -> bool {
     for idx in 0..mac.len() {
-        let recomputed = key[idx] ^ (if *bit { global_key[idx] } else { 0x00 });
+        let recomputed = key[idx] ^ (*bit as u8) * global_key[idx];
         if mac[idx] != recomputed {
             return false;
         }

--- a/atlas-spec/mpc-engine/src/primitives/mac.rs
+++ b/atlas-spec/mpc-engine/src/primitives/mac.rs
@@ -4,10 +4,13 @@ use hacspec_lib::Randomness;
 
 use crate::{Error, COMPUTATIONAL_SECURITY};
 
+/// The length in bytes of an information theoretic MAC, and of the MAC key.
+pub const MAC_LENGTH: usize = COMPUTATIONAL_SECURITY;
+
 /// A MAC on a bit.
-pub type Mac = [u8; COMPUTATIONAL_SECURITY];
+pub type Mac = [u8; MAC_LENGTH];
 /// A MAC key for authenticating a bit to another party.
-pub type MacKey = [u8; COMPUTATIONAL_SECURITY];
+pub type MacKey = [u8; MAC_LENGTH];
 
 /// Generate a fresh MAC key.
 pub fn generate_mac_key(entropy: &mut Randomness) -> Result<MacKey, Error> {

--- a/atlas-spec/mpc-engine/src/primitives/mac.rs
+++ b/atlas-spec/mpc-engine/src/primitives/mac.rs
@@ -60,6 +60,6 @@ fn simple() {
     let b = entropy.bit().unwrap();
     let delta = generate_mac_key(&mut entropy).unwrap();
     let (mac, key) = mac(&b, &delta, &mut entropy).unwrap();
-    assert!(verify_mac(&b, &mac, &key, &delta));
-    assert!(!verify_mac(&!b, &mac, &key, &delta))
+    debug_assert!(verify_mac(&b, &mac, &key, &delta));
+    debug_assert!(!verify_mac(&!b, &mac, &key, &delta))
 }

--- a/atlas-spec/mpc-engine/src/primitives/mac.rs
+++ b/atlas-spec/mpc-engine/src/primitives/mac.rs
@@ -28,7 +28,7 @@ pub fn mac(bit: &bool, global_key: &MacKey, entropy: &mut Randomness) -> (Mac, M
 
     let mut mac = [0u8; MAC_LENGTH];
     for idx in 0..mac.len() {
-        mac[idx] = key[idx] ^ (*bit as u8) * global_key[idx];
+        mac[idx] = key[idx] ^ ((*bit as u8) * global_key[idx]);
     }
 
     (mac, key)
@@ -37,7 +37,7 @@ pub fn mac(bit: &bool, global_key: &MacKey, entropy: &mut Randomness) -> (Mac, M
 /// Verify a MAC on a given bit.
 pub fn verify_mac(bit: &bool, mac: &Mac, key: &MacKey, global_key: &MacKey) -> bool {
     for idx in 0..mac.len() {
-        let recomputed = key[idx] ^ (*bit as u8) * global_key[idx];
+        let recomputed = key[idx] ^ ((*bit as u8) * global_key[idx]);
         if mac[idx] != recomputed {
             return false;
         }

--- a/atlas-spec/mpc-engine/src/primitives/ot.rs
+++ b/atlas-spec/mpc-engine/src/primitives/ot.rs
@@ -116,7 +116,7 @@ impl OTSender {
         selection: &OTReceiverSelect,
         entropy: &mut Randomness,
     ) -> Result<OTSenderSend, Error> {
-        assert_eq!(
+        debug_assert_eq!(
             left_input.len(),
             right_input.len(),
             "Left and right inputs to the OT must be of the same length."
@@ -341,5 +341,5 @@ fn simple() {
         .unwrap();
 
     let receiver_output = receiver.receive(send_message).unwrap();
-    assert_eq!(right_input.to_vec(), receiver_output);
+    debug_assert_eq!(right_input.to_vec(), receiver_output);
 }

--- a/atlas-spec/mpc-engine/src/primitives/ot.rs
+++ b/atlas-spec/mpc-engine/src/primitives/ot.rs
@@ -125,7 +125,8 @@ impl OTSender {
 
         let (left_key, right_key) = self.derive_keys(r)?;
 
-        let (left, right) = encrypt_inputs(entropy, left_key, left_input, right_key, right_input)?;
+        let (left, right) =
+            encrypt_inputs(entropy, left_key, left_input, right_key, right_input).unwrap();
 
         Ok(OTSenderSend { left, right })
     }

--- a/atlas-spec/mpc-engine/src/utils.rs
+++ b/atlas-spec/mpc-engine/src/utils.rs
@@ -1,11 +1,12 @@
 //! Utility functions for the MPC specification.
 
+use crate::broadcast::BroadcastRelay;
 use crate::messages::Message;
 use crate::party::ChannelConfig;
 use std::sync::mpsc::{channel, Receiver, Sender};
 
 /// Set up channel configurations for parties. Returns a vector of Channel Configurations.
-pub fn set_up_channels(n: usize) -> Vec<ChannelConfig> {
+pub fn set_up_channels(n: usize) -> (BroadcastRelay, Vec<ChannelConfig>) {
     let party_channels = (0..n)
         .map(|id| (id, channel()))
         .collect::<Vec<(usize, (Sender<Message>, Receiver<Message>))>>();
@@ -16,6 +17,7 @@ pub fn set_up_channels(n: usize) -> Vec<ChannelConfig> {
         .collect();
 
     let evaluator = party_channels[0].1 .0.clone();
+    let (broadcast_sender, broadcast_receiver) = channel::<Message>();
 
     let channel_configs: Vec<ChannelConfig> = party_channels
         .into_iter()
@@ -24,8 +26,47 @@ pub fn set_up_channels(n: usize) -> Vec<ChannelConfig> {
             listen: rx,
             parties: parties_tx.clone(),
             evaluator: evaluator.clone(),
+            broadcast: broadcast_sender.clone(),
         })
         .collect();
 
-    channel_configs
+    let broadcast_channels = BroadcastRelay::new(broadcast_receiver, parties_tx.clone());
+
+    (broadcast_channels, channel_configs)
+}
+
+pub(crate) fn ith_bit(i: usize, bytes: &[u8]) -> bool {
+    let byte_index = i / 8;
+    let bit_index = i % 8;
+    let bit_value = ((bytes[byte_index] >> bit_index) & 1u8) == 1u8;
+    bit_value
+}
+
+/// Compute the XOR of the componentwise product of two bit vectors
+pub fn prod_component_xor(left: &[u8], right: &[u8]) -> bool {
+    assert_eq!(left.len(), right.len());
+    let mut xor_chunk = 0u8;
+    for i in 0..left.len() {
+        let and_chunk = left[i] & right[i];
+        xor_chunk ^= and_chunk;
+    }
+    let mut result = false;
+    for i in 0..8 {
+        result ^= (xor_chunk >> i & 1u8) == 1u8;
+    }
+    result
+}
+
+#[test]
+fn cross_product() {
+    let a = [0xffu8, 0xffu8];
+    let b = [0x0, 0xffu8];
+    let c = [0x01, 0x0];
+    let d = [0xff, 0x1];
+    assert_eq!(false, prod_component_xor(&a, &a));
+    assert_eq!(false, prod_component_xor(&a, &b));
+    assert_eq!(true, prod_component_xor(&c, &a));
+    assert_eq!(false, prod_component_xor(&c, &b));
+    assert_eq!(true, prod_component_xor(&d, &b));
+    assert_eq!(true, prod_component_xor(&d, &c));
 }

--- a/atlas-spec/mpc-engine/src/utils.rs
+++ b/atlas-spec/mpc-engine/src/utils.rs
@@ -37,36 +37,6 @@ pub fn set_up_channels(n: usize) -> (BroadcastRelay, Vec<ChannelConfig>) {
 
 pub(crate) fn ith_bit(i: usize, bytes: &[u8]) -> bool {
     let byte_index = i / 8;
-    let bit_index = i % 8;
-    let bit_value = ((bytes[byte_index] >> bit_index) & 1u8) == 1u8;
-    bit_value
-}
-
-/// Compute the XOR of the componentwise product of two bit vectors
-pub fn prod_component_xor(left: &[u8], right: &[u8]) -> bool {
-    assert_eq!(left.len(), right.len());
-    let mut xor_chunk = 0u8;
-    for i in 0..left.len() {
-        let and_chunk = left[i] & right[i];
-        xor_chunk ^= and_chunk;
-    }
-    let mut result = false;
-    for i in 0..8 {
-        result ^= (xor_chunk >> i & 1u8) == 1u8;
-    }
-    result
-}
-
-#[test]
-fn cross_product() {
-    let a = [0xffu8, 0xffu8];
-    let b = [0x0, 0xffu8];
-    let c = [0x01, 0x0];
-    let d = [0xff, 0x1];
-    assert_eq!(false, prod_component_xor(&a, &a));
-    assert_eq!(false, prod_component_xor(&a, &b));
-    assert_eq!(true, prod_component_xor(&c, &a));
-    assert_eq!(false, prod_component_xor(&c, &b));
-    assert_eq!(true, prod_component_xor(&d, &b));
-    assert_eq!(true, prod_component_xor(&d, &c));
+    let bit_index = 7 - i % 8;
+    ((bytes[byte_index] >> bit_index) & 1u8) == 1u8
 }

--- a/atlas-spec/natmod/src/lib.rs
+++ b/atlas-spec/natmod/src/lib.rs
@@ -29,7 +29,7 @@ impl Parse for NatModAttr {
         let mod_bytes = Vec::<u8>::from_hex(&mod_str).expect("Invalid hex String");
         input.parse::<Token![,]>()?;
         let int_size = input.parse::<LitInt>()?.base10_parse::<usize>()?;
-        assert!(input.is_empty(), "Left over tokens in attribute {input:?}");
+        debug_assert!(input.is_empty(), "Left over tokens in attribute {input:?}");
         Ok(NatModAttr {
             mod_str,
             mod_bytes,

--- a/atlas-spec/natmod/tests/poly1305.rs
+++ b/atlas-spec/natmod/tests/poly1305.rs
@@ -27,7 +27,7 @@ pub trait NatMod<const LEN: usize> {
         let modulus = num_bigint::BigUint::from_bytes_be(&Self::MODULUS);
         let res = (lhs + rhs) % modulus;
         let res = res.to_bytes_be();
-        assert!(res.len() <= LEN);
+        debug_assert!(res.len() <= LEN);
         let mut value = Self::ZERO;
         let offset = LEN - res.len();
         for i in 0..res.len() {
@@ -46,7 +46,7 @@ pub trait NatMod<const LEN: usize> {
         let modulus = num_bigint::BigUint::from_bytes_be(&Self::MODULUS);
         let res = (lhs * rhs) % modulus;
         let res = res.to_bytes_be();
-        assert!(res.len() <= LEN);
+        debug_assert!(res.len() <= LEN);
         let mut value = Self::ZERO;
         let offset = LEN - res.len();
         for i in 0..res.len() {
@@ -106,9 +106,9 @@ pub trait NatMod<const LEN: usize> {
     where
         Self: Sized,
     {
-        assert!(hex.len() % 2 == 0);
+        debug_assert!(hex.len() % 2 == 0);
         let l = hex.len() / 2;
-        assert!(l <= LEN);
+        debug_assert!(l <= LEN);
         let mut value = [0u8; LEN];
         let skip = LEN - l;
         for i in 0..l {
@@ -131,7 +131,7 @@ pub trait NatMod<const LEN: usize> {
         Self: Sized,
     {
         let max_value = Self::MODULUS;
-        assert!(
+        debug_assert!(
             x <= num_bigint::BigUint::from_bytes_be(&max_value),
             "{} is too large for type {}!",
             x,
@@ -154,12 +154,12 @@ fn add() {
     let x = FieldElement::from_hex("03fffffffffffffffffffffffffffffffa");
     let y = FieldElement::from_hex("01");
     let z = x + y;
-    assert_eq!(FieldElement::ZERO.as_ref(), z.as_ref());
+    debug_assert_eq!(FieldElement::ZERO.as_ref(), z.as_ref());
 
     let x = FieldElement::from_hex("03fffffffffffffffffffffffffffffffa");
     let y = FieldElement::from_hex("02");
     let z = x + y;
-    assert_eq!(FieldElement::from_hex("01").as_ref(), z.as_ref());
+    debug_assert_eq!(FieldElement::from_hex("01").as_ref(), z.as_ref());
 }
 
 #[test]
@@ -167,12 +167,12 @@ fn mul() {
     let x = FieldElement::from_hex("03fffffffffffffffffffffffffffffffa");
     let y = FieldElement::from_hex("01");
     let z = x * y;
-    assert_eq!(x.as_ref(), z.as_ref());
+    debug_assert_eq!(x.as_ref(), z.as_ref());
 
     let x = FieldElement::from_hex("03fffffffffffffffffffffffffffffffa");
     let y = FieldElement::from_hex("02");
     let z = x * y;
-    assert_eq!(
+    debug_assert_eq!(
         FieldElement::from_hex("03fffffffffffffffffffffffffffffff9").as_ref(),
         z.as_ref()
     );

--- a/atlas-spec/oprf/src/coprf/coprf_online.rs
+++ b/atlas-spec/oprf/src/coprf/coprf_online.rs
@@ -194,8 +194,8 @@ mod tests {
         let converted_y_from_1 = convert(key_origin1, key_destination, y_under_origin1).unwrap();
         let converted_y_from_2 = convert(key_origin2, key_destination, y_under_origin2).unwrap();
 
-        assert_eq!(converted_y_from_1, converted_y_from_2);
-        assert_eq!(converted_y_from_1, y_under_destination);
+        debug_assert_eq!(converted_y_from_1, converted_y_from_2);
+        debug_assert_eq!(converted_y_from_1, y_under_destination);
     }
 
     #[test]
@@ -228,7 +228,7 @@ mod tests {
 
         let expected_result = evaluate(test_context, evaluation_key, test_input).unwrap();
 
-        assert_eq!(unblinded_result, expected_result);
+        debug_assert_eq!(unblinded_result, expected_result);
     }
 
     #[test]
@@ -274,8 +274,8 @@ mod tests {
         let res1 = finalize(&receiver_context, blind_result_1).unwrap();
         let res2 = finalize(&receiver_context, blind_result_2).unwrap();
 
-        assert_eq!(res1, res2);
-        assert_eq!(res1, y_under_destination);
+        debug_assert_eq!(res1, res2);
+        debug_assert_eq!(res1, y_under_destination);
     }
     #[test]
     fn test_blind_conversion() {
@@ -319,7 +319,7 @@ mod tests {
 
         let unblinded_converted_result =
             finalize(&receiver_context, blind_converted_result).unwrap();
-        assert_eq!(expected_result, unblinded_converted_result);
+        debug_assert_eq!(expected_result, unblinded_converted_result);
 
         // converting after unblinding and re-blinding
         let unblinded_intermediate_result = finalize(&receiver_context, blind_result).unwrap();
@@ -342,6 +342,6 @@ mod tests {
 
         let unblinded_converted_result =
             finalize(&receiver_context, blind_converted_result).unwrap();
-        assert_eq!(expected_result, unblinded_converted_result);
+        debug_assert_eq!(expected_result, unblinded_converted_result);
     }
 }

--- a/atlas-spec/oprf/src/p256_sha256.rs
+++ b/atlas-spec/oprf/src/p256_sha256.rs
@@ -75,5 +75,5 @@ fn serialize_deserialize() {
     )
     .unwrap();
 
-    assert_eq!(p, deserialize_element(serialize_element(&p)).unwrap());
+    debug_assert_eq!(p, deserialize_element(serialize_element(&p)).unwrap());
 }

--- a/atlas-spec/p256/tests/test_p256.rs
+++ b/atlas-spec/p256/tests/test_p256.rs
@@ -17,8 +17,8 @@ fn test_p256_base() {
         Ok(p) => p,
         Err(_) => panic!("Error p256_point_mul_base"),
     };
-    assert_eq!(point_computed.x().unwrap(), point_expected.0);
-    assert_eq!(point_computed.y().unwrap(), point_expected.1);
+    debug_assert_eq!(point_computed.x().unwrap(), point_expected.0);
+    debug_assert_eq!(point_computed.y().unwrap(), point_expected.1);
 
     let sk = P256Scalar::from_hex("018ebbb95eed0e13");
     let point_expected = (
@@ -34,8 +34,8 @@ fn test_p256_base() {
         Ok(p) => p,
         Err(_) => panic!("Error p256_point_mul_base"),
     };
-    assert_eq!(point_computed.x().unwrap(), point_expected.0);
-    assert_eq!(point_computed.y().unwrap(), point_expected.1);
+    debug_assert_eq!(point_computed.x().unwrap(), point_expected.0);
+    debug_assert_eq!(point_computed.y().unwrap(), point_expected.1);
 
     let sk =
         P256Scalar::from_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550");
@@ -52,8 +52,8 @@ fn test_p256_base() {
         Ok(p) => p,
         Err(_) => panic!("Error p256_point_mul_base"),
     };
-    assert_eq!(point_computed.x().unwrap(), point_expected.0);
-    assert_eq!(point_computed.y().unwrap(), point_expected.1);
+    debug_assert_eq!(point_computed.x().unwrap(), point_expected.0);
+    debug_assert_eq!(point_computed.y().unwrap(), point_expected.1);
 }
 
 use serde_json::Value;
@@ -100,9 +100,9 @@ fn test_wycheproof_plain() {
         _ => panic!("This is not an ECDH test vector."),
     };
     for testGroup in tests.testGroups.iter() {
-        assert_eq!(testGroup.r#type, "EcdhEcpointTest");
-        assert_eq!(testGroup.curve, "secp256r1");
-        assert_eq!(testGroup.encoding, "ecpoint");
+        debug_assert_eq!(testGroup.r#type, "EcdhEcpointTest");
+        debug_assert_eq!(testGroup.curve, "secp256r1");
+        debug_assert_eq!(testGroup.encoding, "ecpoint");
         for test in testGroup.tests.iter() {
             println!("Test {:?}: {:?}", test.tcId, test.comment);
             if !test.result.eq("valid")
@@ -120,7 +120,7 @@ fn test_wycheproof_plain() {
                 skipped_tests += 1;
                 continue;
             }
-            assert_eq!(&test.public[0..2], "04");
+            debug_assert_eq!(&test.public[0..2], "04");
             let k = P256Scalar::from_hex(&test.private);
             let p = (
                 P256FieldElement::from_hex(&test.public[2..66]),
@@ -128,17 +128,17 @@ fn test_wycheproof_plain() {
             )
                 .into();
             if not_on_curve {
-                assert!(!p256_validate_public_key(p));
+                debug_assert!(!p256_validate_public_key(p));
                 tests_run += 1;
                 continue;
             }
-            assert!(p256_validate_public_key(p));
+            debug_assert!(p256_validate_public_key(p));
             let expected = P256FieldElement::from_hex(&test.shared);
             let shared = match p256_point_mul(k, p) {
                 Ok(s) => s,
                 Err(_) => panic!("Unexpected error in point_mul"),
             };
-            assert_eq!(shared.x().unwrap(), expected);
+            debug_assert_eq!(shared.x().unwrap(), expected);
 
             // Check w
             let my_p = (p.x().unwrap(), p256_calculate_w(p.x().unwrap())).into();
@@ -146,7 +146,7 @@ fn test_wycheproof_plain() {
                 Ok(s) => s,
                 Err(_) => panic!("Unexpected error in point_mul"),
             };
-            assert_eq!(
+            debug_assert_eq!(
                 shared.x().unwrap(),
                 expected,
                 "Error in ECDH using calculate w"
@@ -154,7 +154,7 @@ fn test_wycheproof_plain() {
             // // The Y coordinate of the computed point (my_p) is either
             // // equal to y, or -y % p.
             // let other_y = my_p.1.neg();
-            // assert!(
+            // debug_assert!(
             //     p.1 == my_p.1 || p.1 == other_y,
             //     "The computed w is wrong.\nGot {:x}\n or {:x} but expected\n    {}",
             //     my_p.1,
@@ -170,21 +170,21 @@ fn test_wycheproof_plain() {
         "Ran {} out of {} tests and skipped {}.",
         tests_run, num_tests, skipped_tests
     );
-    assert_eq!(num_tests - skipped_tests, tests_run);
+    debug_assert_eq!(num_tests - skipped_tests, tests_run);
 }
 
 #[test]
 fn invalid_scalars() {
     let zero = hex::decode("00").unwrap();
-    assert!(!p256_validate_private_key(&zero));
+    debug_assert!(!p256_validate_private_key(&zero));
 
     let too_large =
         hex::decode("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551").unwrap();
-    assert!(!p256_validate_private_key(&too_large));
+    debug_assert!(!p256_validate_private_key(&too_large));
 
     let largest_valid =
         hex::decode("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550").unwrap();
-    assert!(p256_validate_private_key(&largest_valid));
+    debug_assert!(p256_validate_private_key(&largest_valid));
 }
 
 #[test]
@@ -197,7 +197,7 @@ fn point_validation() {
             "ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
         ),
     );
-    assert!(!p256_validate_public_key(not_on_curve.into()));
+    debug_assert!(!p256_validate_public_key(not_on_curve.into()));
 
     let valid_point = (
         P256FieldElement::from_hex(
@@ -207,7 +207,7 @@ fn point_validation() {
             "43a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
         ),
     );
-    assert!(p256_validate_public_key(valid_point.into()));
+    debug_assert!(p256_validate_public_key(valid_point.into()));
 
     let not_on_curve = (
         P256FieldElement::from_hex(
@@ -217,7 +217,7 @@ fn point_validation() {
             "0000000000000000000000000000000000000000000000000000000000000000",
         ),
     );
-    assert!(!p256_validate_public_key(not_on_curve.into()));
+    debug_assert!(!p256_validate_public_key(not_on_curve.into()));
 
     let not_on_curve = (
         P256FieldElement::from_hex(
@@ -227,7 +227,7 @@ fn point_validation() {
             "0000000000000000000000000000000000000000000000000000000000000001",
         ),
     );
-    assert!(!p256_validate_public_key(not_on_curve.into()));
+    debug_assert!(!p256_validate_public_key(not_on_curve.into()));
 }
 
 #[test]
@@ -241,7 +241,7 @@ fn test_p256_calculate_w() {
 
         // // Check the Y coordinate.
         // let other_y = public.1.neg();
-        // assert!(gy_y == format!("{:x}", public.1) || gy_y == format!("{:x}", other_y));
+        // debug_assert!(gy_y == format!("{:x}", public.1) || gy_y == format!("{:x}", other_y));
 
         // calculate the ECDH secret
         let my_secret_x = match p256_point_mul(private, public) {
@@ -249,7 +249,7 @@ fn test_p256_calculate_w() {
             Err(_) => panic!("Error test_ecdh"),
         };
 
-        assert_eq!(expected_secret_x, my_secret_x);
+        debug_assert_eq!(expected_secret_x, my_secret_x);
     }
 
     // taken from ecdh_secp256r1_ecpoint_test.json tcId=2

--- a/atlas-spec/poly1305/Cargo.toml
+++ b/atlas-spec/poly1305/Cargo.toml
@@ -15,11 +15,3 @@ path = "src/poly1305.rs"
 [dependencies]
 hacspec_lib.workspace = true
 p256.workspace = true
-
-[dev-dependencies]
-serde_json.workspace = true
-serde.workspace = true
-rayon = "1.3.0"
-criterion = "0.4"
-rand = "0.8"
-hacspec-dev = { git = "https://github.com/hacspec/hacspec.git" }

--- a/atlas-spec/poly1305/tests/test_poly1305.rs
+++ b/atlas-spec/poly1305/tests/test_poly1305.rs
@@ -18,7 +18,7 @@ fn basic_test() {
         0xa9,
     ];
     let computed = poly1305(&msg, k);
-    assert_eq!(expected, computed);
+    debug_assert_eq!(expected, computed);
 }
 
 #[test]
@@ -36,5 +36,5 @@ fn corner_case_test() {
         1, 66, 72, 238, 152, 119, 158, 102, 3, 127, 38, 148, 173, 28, 215, 205,
     ];
     let computed = poly1305(&msg, k);
-    assert_eq!(expected, computed)
+    debug_assert_eq!(expected, computed)
 }

--- a/atlas-spec/prp/src/lib.rs
+++ b/atlas-spec/prp/src/lib.rs
@@ -140,6 +140,6 @@ mod tests {
 
         let block = [1u8; 64];
         assert_ne!(block, prp(block, &key));
-        assert_eq!(block, prp(prp(block, &key), &key));
+        debug_assert_eq!(block, prp(prp(block, &key), &key));
     }
 }

--- a/atlas-spec/scrambledb/Cargo.toml
+++ b/atlas-spec/scrambledb/Cargo.toml
@@ -21,7 +21,7 @@ rand = { version = "0.8.5", optional = true }
 getrandom = { version = "0.2.10", features = ["js"], optional = true }
 hex = { version = "0.4.3", optional = true }
 
-libcrux = { git = "https://github.com/cryspen/libcrux.git", rev = "8889c70b1faf26d131f14442f54a5938ab1deff6" }
+libcrux = { git = "https://github.com/cryspen/libcrux.git" }
 
 gloo-utils = { version = "0.1", features = ["serde"] }
 serde_json.workspace = true

--- a/atlas-spec/scrambledb/src/join.rs
+++ b/atlas-spec/scrambledb/src/join.rs
@@ -200,12 +200,12 @@ mod tests {
 
             // test if all pseudonyms are fresh compared to lake_pseudonyms
 
-            assert!(
+            debug_assert!(
                 lake_pseudonyms.insert(entry.handle.clone()),
                 "Generated pseudonyms are not unique."
             );
 
-            assert!(
+            debug_assert!(
                 plain_table
                     .data()
                     .iter()

--- a/atlas-spec/scrambledb/src/split.rs
+++ b/atlas-spec/scrambledb/src/split.rs
@@ -134,7 +134,7 @@ mod tests {
         let mut pseudonym_set = HashSet::new();
         // test that data is preserved
         for pseudonymized_data in lake_tables.data() {
-            assert!(
+            debug_assert!(
                 // plain_values.iter().any(|set| { *set == table_values }),
                 plain_table
                     .data()
@@ -144,7 +144,7 @@ mod tests {
             );
 
             // test if all pseudonyms are unique
-            assert!(
+            debug_assert!(
                 pseudonym_set.insert(pseudonymized_data.handle.clone()),
                 "Generated pseudonyms are not unique."
             );


### PR DESCRIPTION
This PR aims to implements a multi-party bit authentication protocol, i.e. a protocol, where a party can input some number of bits and receive information theoretic MACs on those bits under the global keys of the other parties. The other parties receive the corresponding local keys, which allow them to verify the MAC later on.

To this end the contributions are:
- [x] A simplification of the API for commitments. It's no longer possible to attempt to open a commitment to an invalid value. Instead the opening information includes the expected value and successful opening returns that value. This makes for a safer API since it makes it impossible to continue with an invalid commitment.
- [x] A round synchronization mechanism, since otherwise early parties can move on to the next phase of the protocol soon for later parties to catch up.
- [x] An implementation of message broadcasting via a public bulletin board. The idea is that to broadcast a value, a party sends commitments to that value to all other parties as well as the opening of the commitment to the broadcast bulletin board. Other parties all receive the same opening from the bulletin board, so it is ensured that all commitments contain the same value, since there can be no two commitments that are valid for the same opening.
- [x] A multi-party coin-flipping protocol where each party commits to some randomness and broadcasts the commitments to the other parties. (This is SINE's approach and seems to work even in the active security setting because of the specific commitment we use. In general it's not secure since an attacker could perhaps duplicate other parties commitments and bias the output this way.) 
Fixes #67
- [x] An specification of the information-theoretic MAC. Fixes #49 
- [x] A passively secure two-party bit authentication protocol using the OT protocol as a correlated OT. 
- [x] Building on all the above the specification of the actively secure multi-party bit authentication protocol. Fixes #66 

This means that the protocol as a whole will not be actively secure as long as the two-party bit authentication is only passively secure and we introduce an additional trust assumption with the public bulletin-board. These issues are perhaps to be addressed in a follow-up.

---
When running the protocol on the example circuit (`cargo run --example run_mpc`), I've noticed the base OT is quite slow, due to it using non-optimized speccy implementations of its ECC & AEAD components. When generating a `l`  authenticated bits between the parties, an additional `2 * rho`authenticated bits have to be generated, where `rho` is the statistical security parameter in bits, to do the statistical checks for malicious security. This means it is ill-advised to call `bit_auth` repeatedly with small values when the calls could be batched. For testing the basic functionality I also experimented with what I call "ludicrous mode", i.e. basically without security, by setting computational and statistical security to the smallest possible value. This helped me find some logic bugs, but some might also slip by this way, since the statistical tests of course rely on a high number of samples to find cheaters (or buggy participants as the case may be).
