### PR TITLE
Share authentication protocol

### DIFF
--- a/atlas-spec/mpc-engine/src/lib.rs
+++ b/atlas-spec/mpc-engine/src/lib.rs
@@ -56,7 +56,7 @@ impl From<hacspec_chacha20poly1305::Error> for Error {
 pub const COMPUTATIONAL_SECURITY: usize = 128 / 8;
 
 /// The statistical security parameter, in bytes.
-pub const STATISTICAL_SECURITY: usize = 128 / 8;
+pub const STATISTICAL_SECURITY: usize = 5; // for 5 * 8 = 40 bits of statistical security
 
 // NOTE: The `broadcast` module implements a broadcast utility via a trusted
 // third-party message relay, in lieu of a secure peer-to-peer broadcast

--- a/atlas-spec/mpc-engine/src/lib.rs
+++ b/atlas-spec/mpc-engine/src/lib.rs
@@ -5,6 +5,7 @@
 
 use circuit::CircuitError;
 use messages::{Message, SubMessage};
+use primitives::commitment::COMMITMENT_LENGTH;
 
 #[derive(Debug)]
 /// An error type.
@@ -29,7 +30,11 @@ pub enum Error {
     /// received
     UnexpectedMessage(Message),
     /// Failed to open a commitment
-    BadCommitment(Vec<u8>, Vec<u8>),
+    BadCommitment([u8; COMMITMENT_LENGTH], [u8; COMMITMENT_LENGTH]),
+    /// Failed to deserialize an authenticated bit
+    InvalidSerialization,
+    /// A malicious security check has failed
+    CheckFailed,
     /// Error from the curve implementation
     CurveError,
     /// Error from the AEAD

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -399,19 +399,6 @@ impl Party {
                 }
             }
 
-            for (bit_holder, xored_key) in xored_keys.iter().enumerate() {
-                self.log(&format!(
-                    "Computed local key for party {}: {:?}",
-                    bit_holder, xored_key
-                ))
-            }
-
-            for (key_holder, xored_tag) in xored_tags.iter().enumerate() {
-                self.log(&format!(
-                    "Computed xored MAC for party {}: {:?}",
-                    key_holder, xored_tag
-                ))
-            }
             // d) Receive / Send xored MACs
             let mut received_macs = Vec::new();
             for _i in 0..self.id {

--- a/atlas-spec/mpc-engine/src/primitives/auth_share.rs
+++ b/atlas-spec/mpc-engine/src/primitives/auth_share.rs
@@ -1,4 +1,6 @@
 //! This module defines the interface for share authentication.
+use crate::{primitives::mac::MAC_LENGTH, Error};
+
 use super::mac::{Mac, MacKey};
 
 /// A bit held by a party with a given ID.
@@ -20,6 +22,42 @@ pub struct AuthBit {
     pub(crate) bit: Bit,
     pub(crate) macs: Vec<(usize, Mac)>,
     pub(crate) mac_keys: Vec<BitKey>,
+}
+
+impl AuthBit {
+    /// Serialize the bit value and all MACs on the bit.
+    pub fn serialize_bit_macs(&self) -> Vec<u8> {
+        let mut result = vec![0u8; (self.macs.len() + 1) * MAC_LENGTH + 1];
+        result[0] = self.bit.value as u8;
+        for (key_holder, mac) in self.macs.iter() {
+            result[1 + key_holder * MAC_LENGTH..1 + (key_holder + 1) * MAC_LENGTH]
+                .copy_from_slice(mac);
+        }
+
+        result
+    }
+
+    /// Deserialize a bit and MACs on that bit.
+    pub fn deserialize_bit_macs(bytes: &[u8]) -> Result<(bool, Vec<[u8; MAC_LENGTH]>), Error> {
+        if bytes[0] > 1 {
+            return Err(Error::InvalidSerialization);
+        }
+        let bit_value = bytes[0] != 0;
+        let mac_chunks = bytes[1..].chunks_exact(MAC_LENGTH);
+        if !mac_chunks.remainder().is_empty() {
+            return Err(Error::InvalidSerialization);
+        }
+
+        let mut macs: Vec<[u8; MAC_LENGTH]> = Vec::new();
+        for mac in mac_chunks {
+            macs.push(
+                mac.try_into()
+                    .expect("chunks should be of the required length"),
+            )
+        }
+
+        Ok((bit_value, macs))
+    }
 }
 
 /// The key to authenticate a two-party authenticated bit.

--- a/atlas-spec/mpc-engine/src/primitives/commitment.rs
+++ b/atlas-spec/mpc-engine/src/primitives/commitment.rs
@@ -11,10 +11,14 @@ use hmac::hkdf_extract;
 
 use crate::{Error, STATISTICAL_SECURITY};
 
+/// The length of a commitment value, derived from the output of a HKDF
+/// extraction using SHA-256.
+pub const COMMITMENT_LENGTH: usize = 32;
+
 /// A Commitment to some value.
 #[derive(Debug, Clone)]
 pub struct Commitment {
-    commitment: Vec<u8>,
+    commitment: [u8; COMMITMENT_LENGTH],
     domain_separator: Vec<u8>,
 }
 
@@ -23,6 +27,32 @@ pub struct Commitment {
 pub struct Opening {
     value: Vec<u8>,
     opening: [u8; STATISTICAL_SECURITY],
+}
+
+impl Opening {
+    /// Serialize an opening to a byte vector.
+    ///
+    /// The serialization format is
+    /// `opening || value`
+    pub fn as_bytes(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        result.extend_from_slice(&self.opening);
+        result.extend_from_slice(&self.value);
+
+        result
+    }
+
+    /// Deserialize an opening from a serialization created using [Opening::as_bytes].
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.len() < STATISTICAL_SECURITY + 1 {
+            return Err(Error::InvalidSerialization);
+        }
+        let opening: [u8; STATISTICAL_SECURITY] = Vec::from(&bytes[0..STATISTICAL_SECURITY])
+            .try_into()
+            .map_err(|_| Error::InvalidSerialization)?;
+        let value = Vec::from(&bytes[STATISTICAL_SECURITY..]);
+        Ok(Self { value, opening })
+    }
 }
 
 impl Commitment {
@@ -42,7 +72,9 @@ impl Commitment {
         let mut ikm = Vec::from(value);
         ikm.extend_from_slice(&opening);
 
-        let commitment = hkdf_extract(domain_separator, &ikm);
+        let commitment = hkdf_extract(domain_separator, &ikm)
+            .try_into()
+            .expect("should use HKDF with SHA-256 for correct output length");
         (
             Commitment {
                 commitment,
@@ -60,14 +92,53 @@ impl Commitment {
         let mut ikm = vec![0u8; opening.value.len()];
         ikm.copy_from_slice(&opening.value);
         ikm.extend_from_slice(&opening.opening);
-        let reconstructed_commitment = hkdf_extract(&self.domain_separator, &ikm);
+        let reconstructed_commitment: [u8; COMMITMENT_LENGTH] =
+            hkdf_extract(&self.domain_separator, &ikm)
+                .try_into()
+                .expect("should use HKDF with SHA-256 for correct output length");
         if self.commitment != reconstructed_commitment {
             return Err(Error::BadCommitment(
-                self.commitment.clone(),
+                self.commitment,
                 reconstructed_commitment,
             ));
         }
         Ok(opening.value.to_vec())
+    }
+
+    /// Serialize a commitment to a byte vector.
+    ///
+    /// The serialization format is `commitment ||
+    /// len(dst) || dst_bytes`, where the length is represented as big-endian
+    /// byte arrays.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        let dst_len = self.domain_separator.len();
+        let mut result = Vec::new();
+        result.extend_from_slice(&self.commitment);
+        result.extend_from_slice(&dst_len.to_be_bytes());
+        result.extend_from_slice(&self.domain_separator);
+        result
+    }
+
+    /// Deserialize a commitment from a serialization created using [Commitment::as_bytes].
+    pub fn from_bytes(bytes: &[u8]) -> Result<(Self, Vec<u8>), Error> {
+        if bytes.len() < COMMITMENT_LENGTH + std::mem::size_of::<usize>() {
+            return Err(Error::InvalidSerialization);
+        }
+        let (commitment_bytes, rest) = bytes.split_at(COMMITMENT_LENGTH);
+        let commitment = commitment_bytes.try_into().unwrap();
+
+        let (dst_len_bytes, rest) = rest.split_at(std::mem::size_of::<usize>());
+        let dst_len = usize::from_be_bytes(dst_len_bytes.try_into().unwrap());
+        let (dst_bytes, rest) = rest.split_at(dst_len);
+        let domain_separator = Vec::from(dst_bytes);
+
+        Ok((
+            Self {
+                commitment,
+                domain_separator,
+            },
+            rest.to_vec(),
+        ))
     }
 }
 


### PR DESCRIPTION
This PR contains a protocol for constructing authenticated bit shares from a set of multi-party authenticated shares.
The reason we need this protocol, as described in [WRK17b, appendix B.2](https://eprint.iacr.org/2017/189.pdf), is that after bit authentication "it is still possible that a malicious party uses inconsistent ∆’s when authenticating diﬀerent parties’ shares." This protocol solves the problem by "sacrificing", i.e. revealing a fixed number of the authenticated bits to validate consistent use of the same global MAC key ∆ in a larger batch.

To this end, I've implemented the sacrificing check, which includes extending commitments, openings and authenticated bits by methods that allow parties to broadcast them (or the relevant parts of them), i.e. simple serialization and deserialization methods that allow us to use the existing broadcast utility

The PR also includes a small extension of the `Party` struct by a bit authentication pool, that can be used to store as many pre-computed bit authentications as required for later online computation. A good quality-of-life extension to this would be the ability to store and load pre-computed bit authentications from a file, since the bit authentication is by far the slowest part of a protocol run.