### PR TITLE
AND triple generation

### DIFF
--- a/atlas-spec/mpc-engine/Cargo.toml
+++ b/atlas-spec/mpc-engine/Cargo.toml
@@ -11,3 +11,5 @@ p256.workspace = true
 hmac.workspace = true
 hacspec-chacha20poly1305.workspace = true
 hacspec_lib.workspace = true
+serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -36,13 +36,13 @@ fn main() {
         let c = circuit.clone();
         let party_join_handle = thread::spawn(move || {
             let mut rng = rand::thread_rng();
-            let mut bytes = vec![0u8; u16::MAX.try_into().unwrap()];
+            let mut bytes = vec![0u8; 100 * (u16::MAX as usize)];
             rng.fill_bytes(&mut bytes);
             let rng = Randomness::new(bytes);
             let log_enabled = channel_config.id == 1;
             let mut p = mpc_engine::party::Party::new(channel_config, &c, log_enabled, rng);
 
-            let _ = p.run();
+            let _ = p.run(None);
         });
         party_join_handles.push(party_join_handle);
     }

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -38,7 +38,7 @@ fn main() {
         let c = circuit.clone();
         let party_join_handle = thread::spawn(move || {
             let mut rng = rand::thread_rng();
-            let mut bytes = vec![0u8; (100 * u16::MAX).into()];
+            let mut bytes = vec![0u8; 100 * usize::from(u16::MAX)];
             rng.fill_bytes(&mut bytes);
             let rng = Randomness::new(bytes);
             let log_enabled = channel_config.id == 1;

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -44,7 +44,7 @@ fn main() {
             let log_enabled = channel_config.id == 1;
             let mut p = mpc_engine::party::Party::new(channel_config, &c, log_enabled, rng);
 
-            let _ = p.run(None);
+            let _ = p.run(false);
         });
         party_join_handles.push(party_join_handle);
     }

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -38,7 +38,7 @@ fn main() {
         let c = circuit.clone();
         let party_join_handle = thread::spawn(move || {
             let mut rng = rand::thread_rng();
-            let mut bytes = vec![0u8; 100 * (u16::MAX as usize)];
+            let mut bytes = vec![0u8; (100 * u16::MAX).into()];
             rng.fill_bytes(&mut bytes);
             let rng = Randomness::new(bytes);
             let log_enabled = channel_config.id == 1;

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -12,10 +12,12 @@ fn build_circuit() -> Circuit {
             WiredGate::Input(0),  // Gate 0
             WiredGate::Input(1),  // Gate 1
             WiredGate::Input(2),  // Gate 2
-            WiredGate::And(0, 1), // Gate 3
-            WiredGate::And(3, 2), // Gate 4
+            WiredGate::Input(3),  // Gate 3
+            WiredGate::And(0, 1), // Gate 4
+            WiredGate::And(2, 3), // Gate 5
+            WiredGate::Xor(4, 5), // Gate 6
         ],
-        output_gates: vec![4],
+        output_gates: vec![6],
     }
 }
 fn main() {

--- a/atlas-spec/mpc-engine/src/circuit.rs
+++ b/atlas-spec/mpc-engine/src/circuit.rs
@@ -65,7 +65,7 @@
 //!
 //!
 
-use crate::{party::SEC_MARGIN_SHARE_AUTH, STATISTICAL_SECURITY};
+use crate::STATISTICAL_SECURITY;
 
 /// Data type to uniquely identify gate output wires.
 pub type WireIndex = usize;
@@ -314,8 +314,7 @@ impl Circuit {
 
     /// Computes the required bucket size for leaky AND triple combination.
     pub fn and_bucket_size(&self) -> usize {
-        let and_bucket_size = (STATISTICAL_SECURITY as u32 / self.num_gates().ilog2()) as usize;
-        and_bucket_size
+        (STATISTICAL_SECURITY as u32 / self.num_gates().ilog2()) as usize
     }
 
     /// Returns the number of AND gates in the circuit.

--- a/atlas-spec/mpc-engine/src/circuit.rs
+++ b/atlas-spec/mpc-engine/src/circuit.rs
@@ -314,7 +314,9 @@ impl Circuit {
 
     /// Computes the required bucket size for leaky AND triple combination.
     pub fn and_bucket_size(&self) -> usize {
-        (STATISTICAL_SECURITY as u32 / self.num_gates().ilog2()) as usize
+        (STATISTICAL_SECURITY as u32 / self.num_gates().ilog2())
+            .try_into()
+            .unwrap()
     }
 
     /// Returns the number of AND gates in the circuit.

--- a/atlas-spec/mpc-engine/src/lib.rs
+++ b/atlas-spec/mpc-engine/src/lib.rs
@@ -34,7 +34,7 @@ pub enum Error {
     /// Failed to deserialize an authenticated bit
     InvalidSerialization,
     /// A malicious security check has failed
-    CheckFailed,
+    CheckFailed(String),
     /// Error from the curve implementation
     CurveError,
     /// Error from the AEAD

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -47,6 +47,8 @@ pub enum MessagePayload {
     Mac(Mac),
     /// Values sent over to other parties in the half-AND protocol
     HalfAndHashes(bool, bool),
+    /// Value exchanged during leaky AND-triple check
+    LeakyAndU(Mac),
     /// A garbled AND gate, to be sent to the evaluator
     GarbledAnd(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>),
     /// A MAC on a wire mask share

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -49,6 +49,8 @@ pub enum MessagePayload {
     HalfAndHashes(bool, bool),
     /// Value exchanged during leaky AND-triple check
     LeakyAndU(Mac),
+    /// A two-party bit reveal message
+    BitReveal(bool, Mac),
     /// A garbled AND gate, to be sent to the evaluator
     GarbledAnd(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>),
     /// A MAC on a wire mask share

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -45,6 +45,8 @@ pub enum MessagePayload {
     SubChannel(Sender<SubMessage>, Receiver<SubMessage>),
     /// A bit mac for validity checking
     Mac(Mac),
+    /// Values sent over to other parties in the half-AND protocol
+    HalfAndHashes(bool, bool),
     /// A garbled AND gate, to be sent to the evaluator
     GarbledAnd(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>),
     /// A MAC on a wire mask share

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -530,7 +530,7 @@ impl Party {
             (input[input.len() - 1] & 1) != 0
         }
 
-        let domain_separator = format!("half-and-hash-{}", self.id);
+        let domain_separator = format!("half-and-hash");
 
         let mut t_js = vec![false; self.num_parties];
         let mut s_js = vec![false; self.num_parties];

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -667,8 +667,10 @@ impl Party {
                     }
                 }
             }
+            r.bit.value = z_i_value;
             let z = r;
 
+            self.sync().expect("sync should always succeed");
             // Triple Check
             // 1. compute Phi
             let mut phi = [0u8; MAC_LENGTH];

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -994,13 +994,16 @@ impl Party {
             let (mut x, mut y, mut z) = bucket[0].clone();
 
             for (next_x, next_y, next_z) in bucket[1..].iter() {
-                let d = self.xor_abits(&y, next_y);
-                self.open_bit(&d)?;
+                let d_i = self.xor_abits(&y, next_y);
+                let other_djs = self.open_bit(&d_i)?;
+                let mut d = d_i.bit.value;
+                for (_, d_j) in other_djs {
+                    d ^= d_j;
+                }
 
                 x = self.xor_abits(&x, next_x);
-                y = next_y.clone();
                 z = self.xor_abits(&z, next_z);
-                if d.bit.value {
+                if d {
                     z = self.xor_abits(&z, next_x);
                 }
             }

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -509,7 +509,9 @@ impl Party {
                         "Error while checking party {}'s bit commitment!",
                         party
                     ));
-                    return Err(Error::CheckFailed);
+                    return Err(Error::CheckFailed(
+                        "Share Authentication failed".to_string(),
+                    ));
                 }
             }
 
@@ -832,7 +834,7 @@ impl Party {
             }
 
             if test != [0u8; MAC_LENGTH] {
-                return Err(Error::CheckFailed);
+                return Err(Error::CheckFailed("Leaky AND xor check failed".to_string()));
             }
 
             results.push((x, y, z));
@@ -861,7 +863,7 @@ impl Party {
                     .find(|k| k.bit_holder == from)
                     .expect("should have a key for every other party");
                 if !verify_mac(&value, &mac, &my_key.mac_key, &self.global_mac_key) {
-                    return Err(Error::CheckFailed);
+                    return Err(Error::CheckFailed("Bit reveal failed".to_string()));
                 }
                 results.push((from, value));
             } else {
@@ -904,7 +906,7 @@ impl Party {
                     .find(|k| k.bit_holder == from)
                     .expect("should have a key for every other party");
                 if !verify_mac(&value, &mac, &my_key.mac_key, &self.global_mac_key) {
-                    return Err(Error::CheckFailed);
+                    return Err(Error::CheckFailed("Bit reveal failed".to_string()));
                 }
                 results.push((from, value));
             } else {

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -651,7 +651,7 @@ impl Party {
 
             let v_i = self.half_and(&x, &y)?;
 
-            let z_i_value = y.bit.value && x.bit.value ^ v_i;
+            let z_i_value = (y.bit.value && x.bit.value) ^ v_i;
             let e_i_value = z_i_value ^ r.bit.value;
 
             let other_e_is = self.broadcast(&[e_i_value as u8])?;

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -976,7 +976,7 @@ impl Party {
         // Shuffle the list.
         // Using random u128 bit indices for shuffling should prevent collisions
         // for at least 2^40 triples except with probability 2^-40.
-        let random_indices = self.coin_flip(leaky_ands.len() * 16)?;
+        let random_indices = self.coin_flip(leaky_ands.len() * 8 * 16)?;
         let mut indexed_ands: Vec<(u128, (AuthBit, AuthBit, AuthBit))> = random_indices
             .chunks_exact(16)
             .map(|chunk| {

--- a/atlas-spec/mpc-engine/src/primitives/auth_share.rs
+++ b/atlas-spec/mpc-engine/src/primitives/auth_share.rs
@@ -1,22 +1,24 @@
 //! This module defines the interface for share authentication.
+use serde::{Deserialize, Serialize};
+
 use crate::{primitives::mac::MAC_LENGTH, Error};
 
 use super::mac::{Mac, MacKey};
 
 /// A bit held by a party with a given ID.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Bit {
     pub(crate) id: BitID,
     pub(crate) value: bool,
 }
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// A bit identifier.
 ///
 /// This is unique per party, not globally, so if referring bits held by another
 /// party, their party ID is also required to disambiguate.
 pub struct BitID(pub(crate) usize);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// A bit authenticated between two parties.
 pub struct AuthBit {
     pub(crate) bit: Bit,
@@ -61,7 +63,7 @@ impl AuthBit {
 }
 
 /// The key to authenticate a two-party authenticated bit.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BitKey {
     pub(crate) holder_bit_id: BitID,
     pub(crate) bit_holder: usize,

--- a/atlas-spec/mpc-engine/src/primitives/mac.rs
+++ b/atlas-spec/mpc-engine/src/primitives/mac.rs
@@ -1,6 +1,7 @@
 //! This module defines an information theoretic MAC for authenticating bits.
 
 use hacspec_lib::Randomness;
+use hmac::hkdf_extract;
 
 use crate::COMPUTATIONAL_SECURITY;
 
@@ -11,6 +12,24 @@ pub const MAC_LENGTH: usize = COMPUTATIONAL_SECURITY;
 pub type Mac = [u8; MAC_LENGTH];
 /// A MAC key for authenticating a bit to another party.
 pub type MacKey = [u8; MAC_LENGTH];
+
+/// Hash the given input to the width of a MAC.
+///
+/// Instantiates a Random Oracle.
+pub fn hash_to_mac_width(dst: &[u8], input: &[u8]) -> [u8; 16] {
+    let mut hash = hkdf_extract(dst, input);
+    hash.truncate(16);
+    hash.try_into().unwrap()
+}
+
+/// XOR of two MAC-width byte arrays.
+pub fn xor_mac_width(left: &Mac, right: &Mac) -> Mac {
+    let mut result = [0u8; MAC_LENGTH];
+    for (index, byte) in result.iter_mut().enumerate() {
+        *byte = left[index] ^ right[index];
+    }
+    result
+}
 
 /// Generate a fresh MAC key.
 pub fn generate_mac_key(entropy: &mut Randomness) -> MacKey {


### PR DESCRIPTION
This PR implements authenticated AND triple generation.

It includes
- [x] Rudimentary facilities for loading and storing pre-computed values from a file per party. (This can be removed again later, but makes working on the later protocol part much easier, since we can re-use triples from earlier runs to test new parts of the protocol.)
- [x] the half-AND protocol which computes cross terms for authenticated AND triples. Fixes #68 
- [x] the leaky authenticated AND triple protocol. Fixes #69 
- [x] the oblivious authenticated AND triple protocol. Fixes #70  