### PR TITLE
Top Level MPC protocol

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,11 +34,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
+    - name: Check formatting
+      run: cargo fmt --all --check
+
     - name: Build
       run: cargo build --verbose
       
     - name: Run tests
       run: cargo test --verbose
+    
+    - name: Run MPC example
+      run: cargo run --release --example run_mpc
       
-    - name: Check formatting
-      run: cargo fmt --all --check

--- a/atlas-spec/hmac/src/lib.rs
+++ b/atlas-spec/hmac/src/lib.rs
@@ -52,11 +52,11 @@ pub fn hkdf_expand(prk: &[u8], info: &[u8], l: usize) -> Vec<u8> {
     let n = (l + HASH_LEN - 1) / HASH_LEN; // N = ceil(L/HashLen)
 
     let mut t = hmac(prk, &info.concat_byte(1u8));
-    for i in 1..n {
+    for i in 0..n {
         let round_input = t[i * HASH_LEN..(i + 1) * HASH_LEN]
             .to_vec()
             .concat(info)
-            .concat_byte((i - 1) as u8);
+            .concat_byte((i + 1) as u8);
         let t_i = hmac(prk, &round_input);
         t.extend_from_slice(&t_i);
     }

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -40,11 +40,13 @@ fn main() {
             let mut rng = rand::thread_rng();
             let mut bytes = vec![0u8; 100 * usize::from(u16::MAX)];
             rng.fill_bytes(&mut bytes);
-            let rng = Randomness::new(bytes);
+            let mut rng = Randomness::new(bytes);
             let log_enabled = channel_config.id == 1;
-            let mut p = mpc_engine::party::Party::new(channel_config, &c, log_enabled, rng);
+            let input = rng.bit().unwrap();
+            let mut p =
+                mpc_engine::party::Party::new(channel_config, &c, &vec![input], log_enabled, rng);
 
-            let _ = p.run(false);
+            let _ = p.run(true);
         });
         party_join_handles.push(party_join_handle);
     }

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -41,11 +41,11 @@ fn main() {
             let mut bytes = vec![0u8; 100 * usize::from(u16::MAX)];
             rng.fill_bytes(&mut bytes);
             let mut rng = Randomness::new(bytes);
-            let log_enabled = channel_config.id == 1;
+            let log_enabled = channel_config.id == 0;
             let input = rng.bit().unwrap();
+            eprintln!("Starting party {} with input: {}", channel_config.id, input);
             let mut p =
                 mpc_engine::party::Party::new(channel_config, &c, &vec![input], log_enabled, rng);
-
             let _ = p.run(true);
         });
         party_join_handles.push(party_join_handle);

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -44,9 +44,8 @@ fn main() {
             let log_enabled = channel_config.id == 0;
             let input = rng.bit().unwrap();
             eprintln!("Starting party {} with input: {}", channel_config.id, input);
-            let mut p =
-                mpc_engine::party::Party::new(channel_config, &c, &vec![input], log_enabled, rng);
-            let _ = p.run(true);
+            let mut p = mpc_engine::party::Party::new(channel_config, &c, log_enabled, rng);
+            let _ = p.run(true, &c, &vec![input]);
         });
         party_join_handles.push(party_join_handle);
     }

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -45,7 +45,7 @@ fn main() {
             let input = rng.bit().unwrap();
             eprintln!("Starting party {} with input: {}", channel_config.id, input);
             let mut p = mpc_engine::party::Party::new(channel_config, &c, log_enabled, rng);
-            let _ = p.run(true, &c, &vec![input]);
+            let _ = p.run(false, &c, &vec![input]);
         });
         party_join_handles.push(party_join_handle);
     }

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -54,13 +54,11 @@ pub enum MessagePayload {
     /// A garbled AND gate, to be sent to the evaluator
     GarbledAnd(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>),
     /// A MAC on a wire mask share
-    WireMac(usize, bool, Mac),
+    WireMac(bool, Mac),
     /// Masked input wire value
     MaskedInput(bool),
     /// A wire label, to be sent to the evaluator
     WireLabel {
-        /// The originator of the label
-        from: usize,
         /// The wire the label belongs to
         wire: WireIndex,
         /// The wire label

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -81,7 +81,7 @@ pub struct Party {
     /// Incremental counter for ordering logs
     log_counter: u128,
     /// Wire labels for every wire in the circuit
-    wire_shares: Vec<Option<(AuthBit, Option<WireLabel>)>>
+    wire_shares: Vec<Option<(AuthBit, Option<WireLabel>)>>,
 }
 
 impl Party {
@@ -985,17 +985,6 @@ impl Party {
         }
     }
 
-    fn check_and(&mut self, triple: &(AuthBit, AuthBit, AuthBit)) -> Result<(), Error> {
-        let x = self.open_bit(&triple.0)?;
-        let y = self.open_bit(&triple.1)?;
-        let z = self.open_bit(&triple.2)?;
-
-        if (x & y) != z {
-            return Err(Error::CheckFailed("Invalid AND triple".to_owned()));
-        }
-
-        Ok(())
-    }
     /// Build oblivious AND triples by combining leaky AND triples.
     fn random_and_shares(
         &mut self,
@@ -1576,7 +1565,7 @@ impl Party {
                 let wire_share = &self.wire_shares[input_wire_index]
                     .clone()
                     .expect("should have wire shares for all input wires");
-                let mut masked_wire_value = false;
+                let mut masked_wire_value;
                 if party == self.id {
                     let input_value = input_values[input_index];
                     // receive input wire shares from the other parties

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -71,6 +71,8 @@ pub struct Party {
     global_mac_key: MacKey,
     /// The circuit to be evaluated
     circuit: Circuit,
+    /// The party's input to the circuit
+    input_values: Vec<bool>,
     /// A local source of random bits and bytes
     entropy: Randomness,
     /// Pool of pre-computed authenticated bits
@@ -98,6 +100,7 @@ impl Party {
     pub fn new(
         channels: ChannelConfig,
         circuit: &Circuit,
+        input: &[bool],
         logging: bool,
         mut entropy: Randomness,
     ) -> Self {
@@ -119,6 +122,7 @@ impl Party {
             ashare_pool: Vec::new(),
             current_phase: ProtocolPhase::PreInit,
             log_counter: 0,
+            input_values: input.to_owned(),
             enable_logging: logging,
             wire_shares: vec![None; circuit.num_gates()],
             garbled_ands: None,

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -2078,6 +2078,13 @@ impl Party {
             );
         }
 
+        let (masked_input_wire_values, input_wire_labels) = self.input_processing()?;
+
+        if self.is_evaluator() {
+            let (masked_wire_values, wire_labels) =
+                self.evaluate_circuit(garbled_ands, masked_input_wire_values, input_wire_labels)?;
+        }
+
         Ok(None)
     }
 

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -1976,7 +1976,6 @@ impl Party {
             }
         }
 
-        self.sync().expect("sync should always succeed");
         Ok(output_values)
     }
 
@@ -2046,9 +2045,12 @@ impl Party {
             );
         }
 
+        self.sync().unwrap();
+
         let (masked_input_wire_values, input_wire_labels) =
             self.input_processing(circuit, input).unwrap();
 
+        self.sync().unwrap();
         let result = if self.is_evaluator() {
             let (masked_wire_values, _wire_labels) = self
                 .evaluate_circuit(
@@ -2059,11 +2061,13 @@ impl Party {
                     input_wire_labels,
                 )
                 .unwrap();
+            self.sync().unwrap();
             let result = self.output_processing(circuit, masked_wire_values).unwrap();
 
             self.log(&format!("Got result {result:?}"));
             result
         } else {
+            self.sync().unwrap();
             let result = self
                 .output_processing(circuit, masked_input_wire_values)
                 .unwrap();

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -81,9 +81,7 @@ pub struct Party {
     /// Incremental counter for ordering logs
     log_counter: u128,
     /// Wire labels for every wire in the circuit
-    wire_shares: Vec<Option<(AuthBit, Option<WireLabel>)>>,
-    /// The evaluators list of received garbled AND gates (from, gate_index, g0, g1, g2, g3)
-    garbled_ands: Option<Vec<(usize, usize, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>)>>,
+    wire_shares: Vec<Option<(AuthBit, Option<WireLabel>)>>
 }
 
 impl Party {
@@ -109,7 +107,6 @@ impl Party {
             log_counter: 0,
             enable_logging: logging,
             wire_shares: vec![None; circuit.num_gates()],
-            garbled_ands: None,
         }
     }
 

--- a/atlas-spec/mpc-engine/src/party.rs
+++ b/atlas-spec/mpc-engine/src/party.rs
@@ -59,7 +59,6 @@ struct GarbledAnd {
 }
 
 /// A struct defining protocol party state during a protocol execution.
-#[allow(dead_code)] // TODO: Remove this later.
 pub struct Party {
     bit_counter: usize,
     /// The party's numeric identifier


### PR DESCRIPTION
- [x] Function-independent preprocessing. Fixes #50 
- [x] Function-dependent preprocessing. Fixes #51 
- [x] Input Processing. Fixes #52 
- [x] Circuit Evaluation. Fixes #54 
- [x] Output processing. Fixes #53 

The result of this PR is a fully functional MPC engine that serves outputs to the evaluator. The `party` module is huge and complicated, though. In a next step, I would like to refactor a bit to improve testability by reducing global state in the `Party` struct and separating the communication plumbing from the protocol logic, which should also make everything easier to follow.