### PR TITLE
Maliciously secure bit authentication / Refactoring

### DIFF
--- a/atlas-spec/mpc-engine/Cargo.toml
+++ b/atlas-spec/mpc-engine/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 rand = "0.8.5"
 p256.workspace = true
+hash-to-curve.workspace = true
 hmac.workspace = true
 hacspec-chacha20poly1305.workspace = true
 hacspec_lib.workspace = true

--- a/atlas-spec/mpc-engine/examples/run_mpc.rs
+++ b/atlas-spec/mpc-engine/examples/run_mpc.rs
@@ -45,7 +45,7 @@ fn main() {
             let input = rng.bit().unwrap();
             eprintln!("Starting party {} with input: {}", channel_config.id, input);
             let mut p = mpc_engine::party::Party::new(channel_config, &c, log_enabled, rng);
-            let _ = p.run(false, &c, &vec![input]);
+            let _ = p.run(&c, &vec![input]);
         });
         party_join_handles.push(party_join_handle);
     }

--- a/atlas-spec/mpc-engine/src/lib.rs
+++ b/atlas-spec/mpc-engine/src/lib.rs
@@ -72,3 +72,4 @@ pub mod messages;
 pub mod party;
 pub mod primitives;
 pub mod utils;
+pub mod runner;

--- a/atlas-spec/mpc-engine/src/messages.rs
+++ b/atlas-spec/mpc-engine/src/messages.rs
@@ -4,7 +4,6 @@ use std::sync::mpsc::{Receiver, Sender};
 use crate::{
     circuit::WireIndex,
     primitives::{
-        auth_share::BitID,
         commitment::{Commitment, Opening},
         mac::Mac,
         ot::{OTReceiverSelect, OTSenderInit, OTSenderSend},
@@ -34,9 +33,7 @@ pub enum MessagePayload {
     /// A round synchronization message
     Sync,
     /// Request a number of bit authentications from another party.
-    RequestBitAuth(BitID, Sender<SubMessage>, Receiver<SubMessage>),
-    /// A response to a bit authentication request.
-    BitAuth(BitID, Mac),
+    RequestBitAuth(Sender<SubMessage>, Receiver<SubMessage>),
     /// A commitment on a broadcast value.
     BroadcastCommitment(Commitment),
     /// The opening to a broadcast value.

--- a/atlas-spec/mpc-engine/src/primitives/auth_share.rs
+++ b/atlas-spec/mpc-engine/src/primitives/auth_share.rs
@@ -69,3 +69,51 @@ pub struct BitKey {
     pub(crate) bit_holder: usize,
     pub(crate) mac_key: MacKey,
 }
+
+#[test]
+fn serialization() {
+    let macs_1 = [
+        [1u8; MAC_LENGTH],
+        [2; MAC_LENGTH],
+        [3; MAC_LENGTH],
+        [4; MAC_LENGTH],
+    ];
+    let macs_2 = [
+        [11u8; MAC_LENGTH],
+        [22; MAC_LENGTH],
+        [33; MAC_LENGTH],
+        [44; MAC_LENGTH],
+    ];
+    let keys = [
+        [5u8; MAC_LENGTH],
+        [6; MAC_LENGTH],
+        [7; MAC_LENGTH],
+        [8; MAC_LENGTH],
+    ];
+    let test_bit_1 = AuthBit {
+        bit: Bit {
+            id: BitID(0),
+            value: true,
+        },
+        macs: macs_1,
+        mac_keys: keys,
+    };
+    let test_bit_2 = AuthBit {
+        bit: Bit {
+            id: BitID(1),
+            value: false,
+        },
+        macs: macs_2,
+        mac_keys: keys,
+    };
+
+    let (bit_1, deserialized_macs_1) =
+        AuthBit::<4>::deserialize_bit_macs(&test_bit_1.serialize_bit_macs()).unwrap();
+
+    let (bit_2, deserialized_macs_2) =
+        AuthBit::<4>::deserialize_bit_macs(&test_bit_2.serialize_bit_macs()).unwrap();
+    assert_eq!(bit_1, true);
+    assert_eq!(bit_2, false);
+    assert_eq!(deserialized_macs_1, macs_1);
+    assert_eq!(deserialized_macs_2, macs_2);
+}

--- a/atlas-spec/mpc-engine/src/primitives/auth_share.rs
+++ b/atlas-spec/mpc-engine/src/primitives/auth_share.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{primitives::mac::MAC_LENGTH, Error};
 
-use super::mac::{Mac, MacKey};
+use super::mac::{self, Mac, MacKey};
 
 /// A bit held by a party with a given ID.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,20 +18,20 @@ pub struct Bit {
 /// party, their party ID is also required to disambiguate.
 pub struct BitID(pub(crate) usize);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 /// A bit authenticated between two parties.
-pub struct AuthBit {
+pub struct AuthBit<const NUM_PARTIES: usize> {
     pub(crate) bit: Bit,
-    pub(crate) macs: Vec<(usize, Mac)>,
+    pub(crate) macs: [Mac; NUM_PARTIES],
     pub(crate) mac_keys: Vec<BitKey>,
 }
 
-impl AuthBit {
+impl<const NUM_PARTIES: usize> AuthBit<NUM_PARTIES> {
     /// Serialize the bit value and all MACs on the bit.
     pub fn serialize_bit_macs(&self) -> Vec<u8> {
-        let mut result = vec![0u8; (self.macs.len() + 1) * MAC_LENGTH + 1];
+        let mut result = vec![0u8; NUM_PARTIES * MAC_LENGTH + 1];
         result[0] = self.bit.value as u8;
-        for (key_holder, mac) in self.macs.iter() {
+        for (key_holder, mac) in self.macs.iter().enumerate() {
             result[1 + key_holder * MAC_LENGTH..1 + (key_holder + 1) * MAC_LENGTH]
                 .copy_from_slice(mac);
         }
@@ -40,7 +40,7 @@ impl AuthBit {
     }
 
     /// Deserialize a bit and MACs on that bit.
-    pub fn deserialize_bit_macs(bytes: &[u8]) -> Result<(bool, Vec<[u8; MAC_LENGTH]>), Error> {
+    pub fn deserialize_bit_macs(bytes: &[u8]) -> Result<(bool, [Mac; NUM_PARTIES]), Error> {
         if bytes[0] > 1 {
             return Err(Error::InvalidSerialization);
         }
@@ -50,12 +50,12 @@ impl AuthBit {
             return Err(Error::InvalidSerialization);
         }
 
-        let mut macs: Vec<[u8; MAC_LENGTH]> = Vec::new();
-        for mac in mac_chunks {
-            macs.push(
-                mac.try_into()
-                    .expect("chunks should be of the required length"),
-            )
+        let mut macs = [mac::zero_mac(); NUM_PARTIES];
+
+        for (party_index, mac) in mac_chunks.enumerate() {
+            macs[party_index] = mac
+                .try_into()
+                .expect("chunks should be of the required length");
         }
 
         Ok((bit_value, macs))

--- a/atlas-spec/mpc-engine/src/primitives/auth_share.rs
+++ b/atlas-spec/mpc-engine/src/primitives/auth_share.rs
@@ -23,7 +23,7 @@ pub struct BitID(pub(crate) usize);
 pub struct AuthBit<const NUM_PARTIES: usize> {
     pub(crate) bit: Bit,
     pub(crate) macs: [Mac; NUM_PARTIES],
-    pub(crate) mac_keys: Vec<BitKey>,
+    pub(crate) mac_keys: [MacKey; NUM_PARTIES],
 }
 
 impl<const NUM_PARTIES: usize> AuthBit<NUM_PARTIES> {

--- a/atlas-spec/mpc-engine/src/primitives/kos.rs
+++ b/atlas-spec/mpc-engine/src/primitives/kos.rs
@@ -1,0 +1,40 @@
+//! The KOS OT extension
+
+use std::sync::mpsc::{Receiver, Sender};
+
+use hacspec_lib::Randomness;
+
+use crate::messages::SubMessage;
+
+use super::mac::Mac;
+
+#[derive(Debug)]
+/// An Error in the KOS OT extension
+pub enum Error {}
+
+#[allow(unreachable_code)]
+pub(crate) fn kos_receive(
+    selection: &[bool],
+    sender_address: Sender<SubMessage>,
+    my_inbox: Receiver<SubMessage>,
+    receiver_id: usize,
+    sender_id: usize,
+    entropy: &mut Randomness,
+) -> Result<Vec<Mac>, Error> {
+    todo!()
+}
+
+fn kos_dst(sender_id: usize, receiver_id: usize) -> String {
+    format!("KOS-Base-OT-{}-{}", sender_id, receiver_id)
+}
+
+pub(crate) fn kos_send(
+    receiver_address: Sender<SubMessage>,
+    my_inbox: Receiver<SubMessage>,
+    receiver_id: usize,
+    sender_id: usize,
+    inputs: &[(Mac, Mac)],
+    entropy: &mut Randomness,
+) -> Result<(), Error> {
+    todo!()
+}

--- a/atlas-spec/mpc-engine/src/primitives/kos_base.rs
+++ b/atlas-spec/mpc-engine/src/primitives/kos_base.rs
@@ -1,0 +1,238 @@
+//! This module implements a base OT for the maliciously secure KOS15 OT extension.
+//!
+//! BaseOT taken from https://eprint.iacr.org/2020/110.pdf.
+#![allow(non_snake_case)]
+use std::ops::Neg;
+
+use crate::COMPUTATIONAL_SECURITY;
+use hacspec_lib::{hacspec_helper::NatMod, Randomness};
+use hash_to_curve::p256_hash::hash_to_curve;
+use hmac::{hkdf_expand, hkdf_extract};
+use p256::{p256_point_mul, random_scalar, P256Point, P256Scalar};
+
+use super::mac::MAC_LENGTH;
+type BaseOTSeed = [u8; COMPUTATIONAL_SECURITY];
+
+#[derive(Debug)]
+enum Error {
+    ReceiverAbort,
+    SenderCheatDetected,
+}
+
+fn FRO1(seed: &[u8], dst: &[u8]) -> P256Point {
+    let mut dst = dst.to_vec();
+    dst.extend_from_slice(b"F1");
+    hash_to_curve(seed, &dst).unwrap()
+}
+
+fn FRO2(point: &P256Point, dst: &[u8]) -> [u8; MAC_LENGTH] {
+    let mut dst = dst.to_vec();
+    dst.extend_from_slice(b"F2");
+    let prk = hkdf_extract(b"", &point.raw_bytes());
+    let result = hkdf_expand(&prk, &dst, COMPUTATIONAL_SECURITY);
+    let mut result_array = [0u8; COMPUTATIONAL_SECURITY];
+    result_array.copy_from_slice(&result);
+    result_array
+}
+
+fn FRO3(sender_message: &[u8], dst: &[u8]) -> [u8; COMPUTATIONAL_SECURITY] {
+    let mut dst = dst.to_vec();
+    dst.extend_from_slice(b"F3");
+    let prk = hkdf_extract(b"", sender_message);
+    let result = hkdf_expand(&prk, &dst, COMPUTATIONAL_SECURITY);
+    let mut result_array = [0u8; COMPUTATIONAL_SECURITY];
+    result_array.copy_from_slice(&result);
+    result_array
+}
+
+fn FRO4<const L: usize>(
+    hashes: &[[u8; COMPUTATIONAL_SECURITY]; L],
+    dst: &[u8],
+) -> [u8; COMPUTATIONAL_SECURITY] {
+    let mut dst = dst.to_vec();
+    dst.extend_from_slice(b"F4");
+    let mut input = Vec::new();
+    for i in 0..L {
+        input.extend_from_slice(&hashes[i]);
+    }
+    let prk = hkdf_extract(b"", &input);
+    let result = hkdf_expand(&prk, &dst, COMPUTATIONAL_SECURITY);
+    let mut result_array = [0u8; COMPUTATIONAL_SECURITY];
+    result_array.copy_from_slice(&result);
+    result_array
+}
+
+pub(crate) struct BaseOTReceiver<const L: usize> {
+    sid: Vec<u8>,
+    T: P256Point,
+    bits: [bool; L],
+    alphas: [P256Scalar; L],
+}
+
+pub(crate) struct BaseOTSender<const L: usize> {
+    sid: Vec<u8>,
+    r: P256Scalar,
+    negTr: P256Point,
+    chall_hashes: [[u8; COMPUTATIONAL_SECURITY]; L],
+}
+
+impl<const L: usize> BaseOTReceiver<L> {
+    pub(crate) fn init(entropy: &mut Randomness, sid: &[u8]) -> (Self, BaseOTSeed) {
+        let mut seed_array = [0u8; COMPUTATIONAL_SECURITY];
+        let seed = entropy.bytes(COMPUTATIONAL_SECURITY).unwrap().to_owned();
+        seed_array.copy_from_slice(&seed);
+        let bits = [false; L];
+        let alphas = [P256Scalar::zero(); L];
+
+        let T = FRO1(&seed_array, sid);
+        (
+            Self {
+                sid: sid.to_owned(),
+                T,
+                bits,
+                alphas,
+            },
+            seed_array,
+        )
+    }
+
+    pub(crate) fn messages(&mut self, entropy: &mut Randomness) -> [P256Point; L] {
+        let mut messages = [P256Point::AtInfinity; L];
+        for i in 0..L {
+            self.bits[i] = entropy.bit().unwrap();
+            self.alphas[i] = random_scalar(entropy, &self.sid).unwrap();
+            messages[i] = p256::p256_point_mul_base(self.alphas[i]).unwrap();
+            if self.bits[i] {
+                messages[i] = p256::point_add(messages[i], self.T).unwrap();
+            }
+        }
+        messages
+    }
+
+    fn decrypt(&self, z: P256Point) -> [[u8; COMPUTATIONAL_SECURITY]; L] {
+        let mut messages = [[0u8; COMPUTATIONAL_SECURITY]; L];
+        for i in 0..L {
+            let input = p256::p256_point_mul(self.alphas[i], z).unwrap();
+            messages[i] = FRO2(&input, &self.sid);
+        }
+        messages
+    }
+
+    fn responses(
+        &self,
+        messages: &[[u8; MAC_LENGTH]; L],
+        challenges: &[[u8; COMPUTATIONAL_SECURITY]; L],
+    ) -> [u8; COMPUTATIONAL_SECURITY] {
+        let mut responses = [[0u8; COMPUTATIONAL_SECURITY]; L];
+        for i in 0..L {
+            responses[i] = FRO3(&messages[i], &self.sid);
+            if self.bits[i] {
+                responses[i] = xor_arrays(&responses[i], &challenges[i]);
+            }
+        }
+        FRO4(&responses, &self.sid)
+    }
+
+    fn challenge_verification(
+        &self,
+        Ans: &[u8; COMPUTATIONAL_SECURITY],
+        gamma: &[u8; COMPUTATIONAL_SECURITY],
+    ) -> Result<(), Error> {
+        let gamma_prime = FRO3(Ans, &self.sid);
+        if gamma_prime != *gamma {
+            return Err(Error::ReceiverAbort);
+        }
+        Ok(())
+    }
+}
+
+impl<const L: usize> BaseOTSender<L> {
+    pub(crate) fn init(
+        entropy: &mut Randomness,
+        sid: &[u8],
+        seed: &BaseOTSeed,
+    ) -> (Self, P256Point) {
+        let T = FRO1(seed, sid);
+        let r = random_scalar(entropy, sid).unwrap();
+        let negTr = p256::p256_point_mul(r, T).unwrap().neg();
+        let chall_hashes = [[0u8; COMPUTATIONAL_SECURITY]; L];
+        let z = p256::p256_point_mul_base(r).unwrap();
+        (
+            Self {
+                sid: sid.to_owned().into(),
+                chall_hashes,
+                r,
+                negTr,
+            },
+            z,
+        )
+    }
+
+    pub(crate) fn messages(
+        &self,
+        receiver_messages: [P256Point; L],
+    ) -> [([u8; MAC_LENGTH], [u8; MAC_LENGTH]); L] {
+        let mut messages = [([0u8; MAC_LENGTH], [0u8; MAC_LENGTH]); L];
+        for i in 0..L {
+            let preimg_0 = p256_point_mul(self.r, receiver_messages[i]).unwrap();
+            let preimg_1 = p256::point_add(self.negTr, preimg_0).unwrap();
+            let pi_0 = FRO2(&preimg_0, &self.sid);
+            let pi_1 = FRO2(&preimg_1, &self.sid);
+            messages[i] = (pi_0, pi_1);
+        }
+
+        messages
+    }
+
+    fn challenges(
+        &mut self,
+        messages: &[([u8; MAC_LENGTH], [u8; MAC_LENGTH]); L],
+    ) -> [[u8; COMPUTATIONAL_SECURITY]; L] {
+        let mut challenges = [[0u8; COMPUTATIONAL_SECURITY]; L];
+        for i in 0..L {
+            let chall_hash_0 = FRO3(&messages[i].0, &self.sid);
+            let chall_hash_1 = FRO3(&messages[i].1, &self.sid);
+            self.chall_hashes[i] = chall_hash_0;
+            challenges[i] = xor_arrays(&chall_hash_0, &chall_hash_1);
+        }
+        challenges
+    }
+
+    fn proof(&self) -> ([u8; COMPUTATIONAL_SECURITY], [u8; COMPUTATIONAL_SECURITY]) {
+        let Ans = FRO4(&self.chall_hashes, &self.sid);
+        let gamma = FRO3(&Ans, &self.sid);
+        (Ans, gamma)
+    }
+}
+
+fn xor_arrays<const L: usize>(a: &[u8; L], b: &[u8; L]) -> [u8; L] {
+    let mut result = [0u8; L];
+    for i in 0..L {
+        result[i] = a[i] ^ b[i];
+    }
+    result
+}
+
+#[test]
+fn simple() {
+    use rand::{thread_rng, RngCore};
+    let sid = b"test";
+    let mut rng = thread_rng();
+    let mut entropy = [0u8; 100000];
+    rng.fill_bytes(&mut entropy);
+    let mut entropy = Randomness::new(entropy.to_vec());
+    let (mut receiver, seed) = BaseOTReceiver::<5>::init(&mut entropy, sid);
+    let receiver_messages = receiver.messages(&mut entropy);
+
+    let (mut sender, sender_parameter) = BaseOTSender::<5>::init(&mut entropy, sid, &seed);
+    let sender_messages = sender.messages(receiver_messages);
+    let challenges = sender.challenges(&sender_messages);
+    let (Ans_sender, gamma) = sender.proof();
+
+    let decryptions = receiver.decrypt(sender_parameter);
+    let Ans_receiver = receiver.responses(&decryptions, &challenges);
+    receiver
+        .challenge_verification(&Ans_receiver, &gamma)
+        .unwrap();
+    assert_eq!(Ans_receiver, Ans_sender)
+}

--- a/atlas-spec/mpc-engine/src/primitives/mac.rs
+++ b/atlas-spec/mpc-engine/src/primitives/mac.rs
@@ -13,6 +13,16 @@ pub type Mac = [u8; MAC_LENGTH];
 /// A MAC key for authenticating a bit to another party.
 pub type MacKey = [u8; MAC_LENGTH];
 
+/// Returns an all-zero byte array of MAC width.
+pub fn zero_mac() -> Mac {
+    [0u8; MAC_LENGTH]
+}
+
+/// Returns an all-zero byte array of MAC key width.
+pub fn zero_key() -> MacKey {
+    [0u8; MAC_LENGTH]
+}
+
 /// Hash the given input to the width of a MAC.
 ///
 /// Instantiates a Random Oracle.

--- a/atlas-spec/mpc-engine/src/primitives/mod.rs
+++ b/atlas-spec/mpc-engine/src/primitives/mod.rs
@@ -2,5 +2,7 @@
 
 pub mod auth_share;
 pub mod commitment;
+pub mod kos;
+mod kos_base;
 pub mod mac;
 pub mod ot;

--- a/atlas-spec/mpc-engine/src/runner.rs
+++ b/atlas-spec/mpc-engine/src/runner.rs
@@ -12,7 +12,7 @@ pub struct Runner;
 impl Runner {
     /// Set up and run an MPC session of the given circuit with the provided
     /// inputs.
-    pub fn run(
+    pub fn run_mpc(
         circuit: &Circuit,
         inputs: &[&[bool]],
         logging: Vec<usize>,

--- a/atlas-spec/mpc-engine/src/runner.rs
+++ b/atlas-spec/mpc-engine/src/runner.rs
@@ -1,0 +1,62 @@
+//! This module implements a local MPC runner.
+use std::{sync::mpsc, thread};
+
+use hacspec_lib::Randomness;
+use rand::RngCore;
+
+use crate::circuit::Circuit;
+
+/// A local runner for an MPC session based on MPSC channels.
+pub struct Runner;
+
+impl Runner {
+    /// Set up and run an MPC session of the given circuit with the provided
+    /// inputs.
+    pub fn run(
+        circuit: &Circuit,
+        inputs: &[&[bool]],
+        logging: Vec<usize>,
+    ) -> Vec<Option<Vec<(usize, bool)>>> {
+        let num_parties = inputs.len();
+        let (broadcast_relay, party_channels) = crate::utils::set_up_channels(num_parties);
+
+        let _ = thread::spawn(move || broadcast_relay.run());
+        let mut results = vec![None; num_parties];
+
+        let (sender, receiver) = mpsc::channel();
+
+        let mut party_join_handles = Vec::new();
+        for config in party_channels.into_iter() {
+            let input = inputs[config.id].to_owned();
+            let logging = logging.contains(&config.id);
+            let c = circuit.clone();
+            let sender = sender.clone();
+            let party_join_handle = thread::spawn(move || {
+                let mut rng = rand::thread_rng();
+                let mut bytes = vec![0u8; 100 * usize::from(u16::MAX)];
+                rng.fill_bytes(&mut bytes);
+                let rng = Randomness::new(bytes);
+                eprintln!("Starting party {} with input: {:?}", config.id, input);
+                let mut p = crate::party::Party::new(config, &c, logging, rng);
+                let result = p.run(&c, &input).unwrap();
+                sender.send(result).unwrap();
+            });
+            party_join_handles.push(party_join_handle);
+        }
+
+        for _i in 0..num_parties {
+            let (party, result) = receiver.recv().unwrap();
+
+            results[party] = result;
+        }
+
+        for _i in 0..num_parties {
+            party_join_handles
+                .pop()
+                .expect("every party should have a join handle")
+                .join()
+                .expect("party did not panic");
+        }
+        results
+    }
+}


### PR DESCRIPTION
This includes a number of changes from large to small:
- [x] Simplifying `AuthBit`, since we don't actually need bit IDs and can base everything on indices into arrays of a known length
- [ ] Trying to break up `Party` to make it a communication harness only, so everything else can be tested more easily in isolation
- [ ] An implementation of the [KOS15](https://eprint.iacr.org/2015/546.pdf) maliciously secure OT extension based on [CSW20](https://eprint.iacr.org/2020/110.pdf)
  - [x] BaseOT
  - [ ] OT extension
- [x] An integrated MPC runner, based on the `run_mpc` example

Unfortunately, the base OT we already have since #48 was fixed is not sufficient for secure use in an OT extension, since it cannot achieve UC-security. Therefore I'm implementing the base OT from [CSW20](https://eprint.iacr.org/2020/110.pdf) which was specifically designed to be secure and efficient for use in KOS15.